### PR TITLE
Resolves #25 adds logger abstraction

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,23 +7,22 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01669FB4803C63BF4BCE00528235D34E /* TPLRequestManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4060E6112AF11EA38299B83950146E55 /* TPLRequestManager.m */; };
 		01FDB9509628825F65A36D617903EA60 /* RTUnregisteredClass.m in Sources */ = {isa = PBXBuildFile; fileRef = 480CFE354137A41FA155677A165D6F81 /* RTUnregisteredClass.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		021186FE99D6975FAE757AC8E46558D1 /* RTProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E41157E661E63C9548727BBE60EE4A1 /* RTProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		06426D5F1959BC83B4546AFF3589C285 /* TPLUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D030EA986C2753EE63FC9ECB0524CB7 /* TPLUtilities.m */; };
-		0A73609846EB7600275D5A28D54880CA /* TPLDeviceUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 576A4DF39549B36014CADFF3EF76075D /* TPLDeviceUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0407E6F6F1E2AEE4C3C9A0A9FA204052 /* TPLDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 164545479DF23E9335BF0DA6B8A9F06B /* TPLDeviceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0BECDC96A5E3FF53E85E67C2C8A966C1 /* Tropicalytics-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AC49A5BFE891F8DB5C468C22951E853 /* Tropicalytics-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0C6FF91EB1F0391ED75DC72D31D159EF /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = 673E0F3028CF6C1C26CF58F579A2096E /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		0D16B556212D317A0D4FEB71E102E207 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 40D00DFC6A32F78AB78B589250AE2967 /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DCDA6049704B2AF1DA42EC6D1CFE236 /* Tropicalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 45BF5605466A9EC4C5FFBA9B24630B73 /* Tropicalytics.m */; };
 		0EBFA5FBE4953A83B677CE2A75746761 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = B91DEF511AAE5AB047AC6233D7FA1AC5 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		0F94F5B0ABB3252B9275B7C129EC7A26 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = EEC75ACA62ADAEFB0A5D1F782A08BFC4 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		11C1AEB289C1EB80089349B71F09D04B /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 43D8F3D174DE77DE4B86232693B09BD0 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		12F95AEFF8EB3F9ED139C6D26B9C8264 /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ED102F8589E200C5F73DC52E42CFF9F /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1312A7D381C51428CF481E33E3D37901 /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = D4AA48A433ECB2BBF26BC7A11505F014 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		131532787AD40BE1F35DF288D2E6FFD7 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 91058F81BD0433273EC4438A9174CED0 /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		141D68FA80C9DC5B2224318BF1862811 /* TPLUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 58311F9E386D1351EC2156550E15D577 /* TPLUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		142B53747754027E796F8A767A9A5823 /* TPLUniqueIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D3B9B3D632038AA99FCE3742E1AE455D /* TPLUniqueIdentifier.m */; };
 		1480F4923DBBF217F60572EEECB4027C /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3FAF391B2C5938158F8CCC8BA698BD /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		160FDA46EE919AAF97E0E4EC04C9E232 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		162E5BB758F4CB54170B830540787EB3 /* TPLUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 130CC6DB667C8B547C3B579A24E2E256 /* TPLUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		164B2A363F9B0096A792A69320A30D42 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = DDCE0EBDBFD893D8A128BD9507A95CC6 /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		174202BD6AE0E4A41F5CE66E975EAE52 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E052C84528CA562DE6AD1FAFB1483E3 /* UIRefreshControl+AFNetworking.m */; };
 		17572374B2AE183C6347C41E8DF8E579 /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 87662EBF42E6FAD0E92226F8163E2E5B /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -31,18 +30,21 @@
 		1A1AB2EC52323C5EA28DAA99F1E1A90D /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 885C7DBB171E6DEEAA643351A6772262 /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AB3304B6884F626BC54150AC7565E18 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D5E394CB2E1B19ED3577784F31F85 /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		1B0389CD88AA949B34DC7269030FEC6F /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4C8968A88660F583FC622128E2ED22 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1B261CF95B938F1D0008605B106CF1B3 /* TPLBatchDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ADC98DE8770735CA0A60367EBDEDD57 /* TPLBatchDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1B4583D6E68B3C76C754D57835707F89 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20FF7AC81EFEBB6E722B793E7EE47F8F /* XCTest.framework */; };
 		1E5B8F12ED7CC40ECDB9B1F755F387E5 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CBED299A0FBDE512F7165485EF5EE88 /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		201BF9C605852822CA5A65ADE282A310 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CD5EDF0B03235EAC81199D4B695802CD /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		204D694B03BFF3B244A6AB73FACFFC43 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E46DD46C9B83578FA4AB3E4E99AA6060 /* Expecta-dummy.m */; };
 		20607BE2B1E5F31765026E5AC64DB27D /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = C7AEFEFED9284ADC51610E077D769673 /* AFSecurityPolicy.m */; };
 		20EE8030FCF2402DAC7F1C9B9DDAEF79 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 093B510C608944D5C2F42932F5BA6070 /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		22D9820B5F9517A438CBF36234D0BFFC /* TPLBatchDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = 84CC80A7E6D99680653564663C3A4BB4 /* TPLBatchDetails.m */; };
+		22F44DF51F618EA55D828D413627BFF5 /* TPLEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E0DE0B6FF0FE3F8D7AC0A6A50829E6CD /* TPLEvent.m */; };
+		22FD653C2E038A549A94103DF8405154 /* TPLAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AB59C9F37BE0F0C6919BAF2DBDC4AF0E /* TPLAPIClient.m */; };
 		23500E6D25DA1901837F20BB447C21A8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
-		235C61898C33FA8CE7181EB8086EAB52 /* TPLRequestManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E23A667DB8C23D87B3D5E5BDD4343FD0 /* TPLRequestManager.m */; };
 		23DC772ACCF5806AE9CFDA1604FC400C /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = AA07502408A9CA91389B8D50F3018B7A /* SPTCompiledExample.m */; };
 		260BC7EED9289AF321A6F791964CE472 /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 202FF15792933080E43DF6C3BCDFFAFC /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2810F816A41B60EC24C3D882D83AF212 /* RTUnregisteredClass.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4E141AC4C5452BDF7C20C57881C711 /* RTUnregisteredClass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2845AFC4EC310D21911987193AE6DC2F /* TPLConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF940F6BB905B79E5937540D3AAF858 /* TPLConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		289AC0D5AD03FFBB201A7A7F634D77F0 /* TPLDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2D1FD5984A4544E0D7B9124D25819 /* TPLDatabase.m */; };
 		2916A0606136A9DC67F2463AB230868B /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = E0311F0CA5EBFD85E51FC577126C74ED /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2C0A8737FDB9B9C6A6BDF437FD11334C /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = C0E2D7FB534E463EF3F0180767F9BF2E /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		2CFE2898496C1C7096DB8DA43AF19103 /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = A9F1435AF8F9F903D34031C41619D1D8 /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -51,18 +53,16 @@
 		2E7F13CBDDBD5D1E32FD42D6A99F6EFD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
 		2E8A32ED46194EDBE22146271F6D26DE /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = E89085B4B3B8B3F1F6AFABC95047B569 /* UIImageView+AFNetworking.m */; };
 		2F427490ACABC4408D57CC0592276678 /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = CAAF695DDD22B3FB18EFDFE29859B1F6 /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		30FDA563476F43403FDD7DFF7C8D7FD4 /* TPLDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CAE84B93735472042028094A2703C28 /* TPLDeviceInfo.m */; };
 		33BC013B3C8F98E74D039CB62CBBFBC6 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = D00B1214FB2249B17D63477FC575F1BE /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		341F8F1652A7DE6AADAA3331CA6320CB /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 56861037EA61E8AC037C859257B60195 /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34B6E9A30603BEBBD87BA535B7D384CA /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 32B76F9E3E7B6D0A432ECFFEAE9E2641 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		361FEF17E7327A9901B6F06BA40EB7AC /* TPLRequestStructure.m in Sources */ = {isa = PBXBuildFile; fileRef = FC00653319BE88CF47CCD1D46F01737C /* TPLRequestStructure.m */; };
+		359CDFFF69DCE47CA172F6104B2D1C99 /* TPLFieldGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 84AA5CDB9D52805094789EE53A5F1198 /* TPLFieldGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		372F7A9CCE59CE86316CF436F832A3FC /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE020DA7F324BBDC31D5B9A482D6582 /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		37A2D0F8493469EF2495FC689440F079 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 42962234757A0B0C5FB571FFFCE674FB /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		397B320B7C59C168CC5B62E18ED8DEA0 /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = DED59F076B9E088A6E5F98EB8C00BC86 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A10EF6ABF51D1D00B06AC5EF3A8C28C /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41EA7EE51CA28000254601EFA38F3774 /* SystemConfiguration.framework */; };
 		3A31EDB6BCFB40F2DE1A3A68A6071960 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 729EE2B07BC4CE1C4963B64E42594C3B /* XCTestCase+Specta.m */; };
 		3A36886057E5A931014ACC66023B8431 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 093B78EA86E54DC4F3A1B2F947989BD8 /* CoreData.framework */; };
-		3A640CF561D23145D1452C819704662E /* TPLFieldGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = DFCE673A37F9BAFA03DB68C1D11B50EA /* TPLFieldGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3B57335169177F4A558D98236BD8D38A /* Tropicalytics.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 736825C14AB0DC5059B2304F01FCE599 /* Tropicalytics.bundle */; };
 		3B5B7495707BF7133B9FB3F834045611 /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C1D32078D598BC895DA140F206554C45 /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C2700C7DAA15C6AF84A595865C42F4D /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = B905271BF44822792EA48DF27A4B6416 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -70,18 +70,16 @@
 		3F1BC9BAFFEEABB1ABC7614DF0FC97D5 /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E8797EDA66E9459C5155CC5750A8543 /* AFAutoPurgingImageCache.m */; };
 		403292D82DA62291204BF59524BC4EDB /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 24978C0D139A516F137BABEAEB5E98A7 /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		40583F11C8BEB933BFC82864F7C2869C /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD3A2AA836ECFC16788AD4653B3C797 /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		45CA647C8D95428293EFEFA28E32F051 /* TPLBatchDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FF42A4A7268F96C32CA12AC558FB3F28 /* TPLBatchDetails.m */; };
 		46137F5CC368BF38BAF0D0AF81DD8FFE /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D165B527C6B04FA62635FA695DF34C /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		471FD4F68E27AB26FA2AEBB8B245CEE4 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 41C3C6F32FCB975511D64FED50808F68 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		494767D9F1B586F1F97BF993498F002F /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D5C62B64A0A67B6535BE66A210B01F3D /* Specta-dummy.m */; };
 		4BBCBB9D8EF0B241A4A4FE4982985481 /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 66C43973FE9B62E95CB3E3926B978E49 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4D48F6B0E27B943FB08C4B239DCC8ADE /* TPLDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = EFF921E21ED93627AEB75F0A09E30F9C /* TPLDatabase.m */; };
-		503755BC95009E1959B466127718DA50 /* TPLAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FEB7F31DDC5FD6CB74C1CEA3597B455 /* TPLAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		50A23FF732C8451CACE6FBE28C3A5474 /* TPLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F2E1D828EA50853EA092D01F148A539 /* TPLLogger.m */; };
 		51DDDB0FB4899757CF6A826B531B940D /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 867D9AF4FF470DA68D363C120DB72FA6 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		51FCCD21A3089CCA665996F22547ED83 /* Tropicalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB3B9454DCB371FA3386BDCE789AEF0 /* Tropicalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		527EBD9ACF98B1D5DB32C4AB2CBA84EA /* TPLAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F362A60E0B5E9843ECA5FD436385F51D /* TPLAPIClient.m */; };
 		536293D7AF840017A21EC63E1B811A2E /* MARTNSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BCC7698FC5E579C04A61927C14ABB1C /* MARTNSObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		54A0C3FBD14A988F3D43754CA98D9CAF /* TPLAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D8AF91C67AA77190289868861FF5D35 /* TPLAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		553B6989768B187B16B1E127D813AE20 /* RTIvar.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C374A2B748E32B91C4451F28EC52A41 /* RTIvar.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55965D7A34B02E6E208A95FF0B22D995 /* TPLRequestStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BB0215F89C0EF6195EC1EF6849B09EC /* TPLRequestStructure.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		560698A4D707DCBCC1C8F98BC9B89B23 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BD8DA0F7C54949412A8BA81A6DCDDF99 /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		57C82EC703961B78511B46C6EEBB70A7 /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B539990DF3D9D6F061F705BD1AB97CB /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5808B477EFF509D810B5CDCFDC944F80 /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 4747BD40B00A4C264B2D57BB66B42BD0 /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -89,14 +87,15 @@
 		599298371E33787177EF97722CF48412 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = B240313F1B213A37D8975DAC2B614D78 /* SpectaDSL.m */; };
 		5B2D4A621D3DA971A474776AF36BB073 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 74134635D078692BF3F5DEFB39EC00DD /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		5BAD8306315E116F6E8E76552EC5B665 /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = ED5A9AB9707480312760E8FCD2DB7786 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5E9CA582E721C549637005F30C784AE9 /* TPLDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 13A7E9A10DFB5D87FEFDDB08259CFF83 /* TPLDeviceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E9AF174013C55BB85587D7BA855AB72 /* TPLBatchDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = E260E7130DF3C13D73D7B54E2D171C0F /* TPLBatchDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5EA7043FE10E75D02F3C3052AF8B8318 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = A51AFA314793A1C7F3DF89A27FD7CAF6 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5F9C09A207929B44F9387B3DCF2F8A77 /* TPLDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 13488CCDD5B88F0AEA69EB00932D8D5F /* TPLDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FF6453E55785669885F626B853FD2AA /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA47031DF3A795E8CB1AFB6336BDFF1 /* UIProgressView+AFNetworking.m */; };
 		60E3009342BEE96D32C546BE2DB60052 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 07F895A256F1D4DA24CC9DF911735063 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63CEFA7B13F25A41BC8D464D50093C78 /* TPLRequestStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = C1387C8F2BF159F1425D5CF27EFCB83C /* TPLRequestStructure.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		64F8D0C788524AB5A359D9D2BB50A15C /* TPLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 047288603106E9DC568A16057BDD601F /* TPLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6505040F539B64D37A12448BAD2F0FC3 /* Tropicalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 551B8CC87D7B16D99AC216293F566DD0 /* Tropicalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		659960F7E28E993E08CCC1E8A383E710 /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 5173BEA05027A0482238C295B668F172 /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65BC31095CCDFC80CBF6BBA843751F23 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 237E461836957B621999D3DE5C0FE73C /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66289DBD8CACCB555A1C308C07B15753 /* TPLUniqueIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = FCE281B7361F6D285467236E2C55B4F7 /* TPLUniqueIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66A27898E989A3FA5C15AA671C4536F0 /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 307BBB64F62EB5941021C1482CF822B7 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		67459AD239EF669A365519E06B45DCFE /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 82DAA1EFED847C2CDE1357092F1FA251 /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68152D921ABF6A423C192C04FDF94F0F /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BAE57C33490B0B1AF6088B01E11F886A /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -104,7 +103,6 @@
 		68A38977EBAE334DC3C22386D00D2622 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 62B05FDD26E59490F648E62593C27DAB /* AFNetworkReachabilityManager.m */; };
 		6C3940612920F2F97069AF6AAF4BDAFD /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 519AED277A8B6E3B62C824D9845B4BDC /* SPTExample.m */; };
 		6E1D978790705E137FDE439AA68DD3AA /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF866059F140F5989F0BD8B787F534B /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6EC22B550ECF7AC97B97845FA6D64F76 /* TPLConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D3BD0BE3B6F01ED6B6EFEA7FB20ED7F /* TPLConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6ED4ABEE8A5F51F5ECB59FA1781D29C6 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 890B11D7D6F4BFBEECD999A94E27A786 /* UIActivityIndicatorView+AFNetworking.m */; };
 		6EFC63A5CED45BB39FC79D87F2C47D6B /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F73FBFCCE22E56C194C05BE1638EB59 /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6F278423C8AE1DA47F35E374BB5B91EC /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CD2665763950A3C776E1B07609F9766 /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -116,87 +114,92 @@
 		78A09642B8D3048606BCE3CDC2019071 /* RTProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = AC3EC58E73C4FD397442C88C140EA6B9 /* RTProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79558B1F97ABE4AB8942DC18BEBD4B82 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E2AA3BD43F0531C251D67BB29CD3D9 /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7A211860F672261C1522DCDF1FFC9ED0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20FF7AC81EFEBB6E722B793E7EE47F8F /* XCTest.framework */; };
-		7AF2D65C39AAD532A5C685B09146F5C7 /* TPLConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D006D7BFBEB28BA7914E657DDFEB52 /* TPLConfiguration.m */; };
 		7B223B4E6EF14BA12DA113F7EE10B96C /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 5908EB1D8C9A560497B037792FCA3E12 /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7E6A4EFA32969CDB9F9C57903152BA54 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A33BF6D48242005A5EE8B489B416344 /* CoreGraphics.framework */; };
 		7F17EA5E2787B6F2BBB359854B42A0E3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
 		805E425BBEF7A6133E32E1D30A073010 /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = D3FD828DDF23CB2D5927E7ADAD3B0FF8 /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		81B617F8D26BB10C5726D75E85D21EB7 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 760BE70119445BF8B9C8C842A50BEFB6 /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81E0DB04CED585BE1AF0A843A1EFDEAE /* MARTNSObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C002BF73CF9ED768EC47A919CD0B7B8 /* MARTNSObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		82D0CAC88D65DB9338E1D30540FEE9DB /* TPLAppUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 3491748A7B4AA117CC8057F27173E36F /* TPLAppUtilities.m */; };
 		837B593D7C1D01B4EA400247309D6AB0 /* Expecta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AAE48B66D04BFE93C713663A4CD3643 /* Expecta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		85E31076D5530AEEB45ACF16B2B8A983 /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A4D8B739AB877CAEE4AF331A3D61112 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		85EB2F216487CB2E8F3FCCFBC4D69912 /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = E6C6D7BC17B35FF9C88A48F86720F247 /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8633BE2B6F523A83EDCAFAB77EBC4AD3 /* RTProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = 32BB5BC09F3C0D17A752244A07F34C15 /* RTProperty.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		878D7F4E75179B2E9800E12DECE0C166 /* TPLFieldGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498621F79A2955C9783E161A45BF094 /* TPLFieldGroup.m */; };
+		87035CF509BAD81C1C2EFC3D22DDF222 /* Tropicalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = D7E2BCFE6849E4F19C28F7CDACE43F0D /* Tropicalytics.m */; };
 		87FD5F0F682CDEB6A348CA448889E3EA /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = F9EB460416B1C4938820DC263FB509EC /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		884E62C59DCFD8F1FBF4B3F3324BE069 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		8B61C72CD1E2A9CC1D2047DAF5ECBF4A /* TPLConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = D282EF46E30FE460ED014781F69E2986 /* TPLConfiguration.m */; };
 		8C8C1B0D83FE6A4352F15154DB16372C /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 4663392B2E73D349D33F16F83710E55A /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8DC751D799A71AA97FD7F5DE1A171210 /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD57EDC7684E72652BEFB94BCBBB0F3 /* SPTCallSite.m */; };
 		8F3C7283335959E7FBFD25BDC7B376CD /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = CE56C189D1436871EA1BEF1E230581CB /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		90648186E4DCE8FBC35EF12467573D2A /* TPLHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 95BA1215E0586C731647CD503549C688 /* TPLHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		918E06480F28F27361B19D19432F8538 /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 9924A1DA480804CCE203BFF7F4938D30 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		931D410B9F8ACB935883DF8C59F9C93E /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C92071F7B076D2F78266367E35DA299 /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		9436299B947A7E6B7474EEB264505FE3 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 40F2ED78511D7AE9C2C461E14BA0FEDE /* SPTExampleGroup.m */; };
 		94C47C87E397972CE98F75929F3B706C /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 65C93B27BBA2E2D35A1F21DB63014370 /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		95231D238DD1A503B6F0F4E7C5BEDEB6 /* TPLUniqueIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E080A468BB5AB2A2C21E26E63537E2 /* TPLUniqueIdentifier.m */; };
+		97DFEBFF82A9ECDAD76CED380BEDD64B /* TPLUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = B85934045C854BC4174320093054F76C /* TPLUtilities.m */; };
 		9B2E761A064459F77EA9870BEF03ACC3 /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E16264C985F34BC3E5C6833CCAE1C2 /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9BB9159FBA757600D3D4C0FF645F3911 /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 408A7AF14F4CCE770A8EF0288E3B0F4E /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		9C718EF9D4A9B42767423E4D767BCF68 /* Tropicalytics-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AC49A5BFE891F8DB5C468C22951E853 /* Tropicalytics-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D328BF4B14CF5DCC4AD70B5CFA3BE26 /* TPLAppUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = EB30A65827FC7341E7E0C51169319CE8 /* TPLAppUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9E1E90DED74B73ECE53C9AD76DE53E2D /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4C09D5ABB3852A4B6BB308211FB888 /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A462945883F7729B185B64B679A6BFBE /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CCD624B009530E994DF7F1F347DBF70 /* UIWebView+AFNetworking.m */; };
 		A55368BBDD7417464F40151C5F9B6A09 /* MAObjCRuntime-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 824A89C3ED13835DC40D6AF7EC2093E8 /* MAObjCRuntime-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A5A0FA36ED5B6A70AA00971C7EB17D0D /* TPLUniqueIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = DE020FB523FB2ED465D9A801433C25C4 /* TPLUniqueIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A6C6019D45BE62C61210A9CC619368EF /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 415E5DB48EDB900698A89CAA7404A890 /* AFNetworkActivityIndicatorManager.m */; };
+		A8EBD606B6BBECD41DD742AFF4BDA89C /* Tropicalytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BECD7A1B03527A00FDC7416D15C3DFAD /* Tropicalytics-dummy.m */; };
 		AB39AC9746E7575D7449700475E41B0B /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C4DF160A02BC4D99EB5BF20C1B9E1C37 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC9BA05FC3672457AD6AC317D2A819F9 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C28D7A068FD5494806D45CF62CAAE12 /* SPTSpec.m */; };
 		AE2A07407FB50BA249984DC0620E84C0 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C1115012E054B7D6FCC123E9978886 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AF03C11A1FAC8132AD3749D8F541701A /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 1758E125466BAD91C4772A1EE949ADDF /* UIButton+AFNetworking.m */; };
 		AF1F46668D4591602887998C6E9C10AD /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BC27F5BB3011BCD928586C46E44B88A /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AFCD2F24E460A91646724C530026C6B6 /* TPLEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 41AD34E12BBFA99A6B57082122F6016B /* TPLEvent.m */; };
 		AFFC8900E52BBEC72059334132F3A8F3 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 81A4C6359BEA818EE50CE3AFF5CBF3F8 /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B05DD383D9D1887FD8F83A8D7415A095 /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = AECB9DB0D789BA63A4E2DB48E9F911FD /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5852322ADE88AAD56EE042B80BA81E4 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 320E4F1C0A54C8EDCDB43A020085444E /* AFURLResponseSerialization.m */; };
 		B84431CF8C64F363A334AA7089F6C134 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 39A8A444600147CF4FD261431427F59F /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		BA12B131F10BCE3BE6E9A02FC908FE9D /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C25F11412715116910791D675543C9 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BAB2AA805CA5BC4066BD3E50BE971FC9 /* TPLDeviceUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = ED92165F8B9C879DB4610C81E38058A6 /* TPLDeviceUtilities.m */; };
 		BC55C8365AEFF8217F6A567607754854 /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FB73A2F8759492AB49BBF7D89AF63B5 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BD5C86C8C57B375155A3C320E93FC87D /* TPLRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 234BFF3EA1DD991B98A81BFB561D162F /* TPLRequestManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BEFFE9FFE52E9A0833A7D2D8FB67EB4D /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = E67D9EF3FAE85219A5649B6A3F23E794 /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BFA4AB7B2A09DE80E24FAD21714C45B4 /* TPLDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = AC7F6730CD182DEA662C25BCC89D1B4A /* TPLDeviceInfo.m */; };
 		C00782B6CD46D9EB56C5F8DBD892DC93 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 161E2A5870AA71357EFB5D3A08330839 /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C01AC3BAD9037A8A1E45FD17336C15F3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B24FD7D9D711C287927C6E7642219553 /* Security.framework */; };
 		C2CF0EB220F8F42DF5398D53B0AE5A0C /* AFNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2315E4A1E1EA4063E89ABC988B323712 /* AFNetworking.framework */; };
 		C2DD28375E1F0B1D0D1D2E4E607C499F /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B83BAEE37ED9AFFCB71B34E701449EB /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C486094162F0CE60103DECF13ACB4856 /* TPLRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C94407A625C4216447458F88047D40F /* TPLRequestManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6354FEC7728A4C86DAD8092509BA7D4 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BD0820FED0B34F7C4C4F85F5A9093331 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C782AC36CFE36AA4324D41C0B4EB0310 /* RTMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = BC298EF491113D68B9F125ED633F3073 /* RTMethod.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C7A1C0E86C9661BDFC5F63764EB0C7E0 /* TPLHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = A0580DDE998769BF43C5DF87DD71E9D1 /* TPLHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C834C57C115A6D9667B7296B80C019E2 /* Tropicalytics.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = B7D3CE739FD62D60A1A6C12A25AD624E /* Tropicalytics.xcdatamodeld */; };
-		CA9E224E570347EAF99DCE6362875EFD /* contents in Sources */ = {isa = PBXBuildFile; fileRef = 17BF2D4F6A1BB77020E36C934D3C7E40 /* contents */; };
 		CAC483EF637FB4A2C2E2FC75BA631B87 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 19EAFD051A6357D7CE67EF4289B99565 /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAD1658B88880B4F5417D922D6970902 /* TPLDeviceUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C917F8787CF569EF56457769E018EA1 /* TPLDeviceUtilities.m */; };
 		CBB5E3ADE44538D569D63A9FF7003BB4 /* Pods-Tropicalytics_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EF3503053D357443A7E767A8610313E /* Pods-Tropicalytics_Example-dummy.m */; };
-		CCF834C2EFA77D681712D7E80D023FBC /* TPLConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A4CF28A5A94F30094CE80FB91936AC6 /* TPLConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE3F4ECBB0BC095577D66AE50C8E604C /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 964C5C701CA5BE5F3E809764EED57730 /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		CE7416A504B2D1121091BEED0F07EA75 /* MAObjCRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860E8360D18B7E55222AD02C6FA6866C /* MAObjCRuntime.framework */; };
-		CEC63042960076B25C3479EA25B3283B /* TPLEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = D262B00A268E742F2278EA07BA8E8A44 /* TPLEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CF9B2FFFB9BD02A2AAC06922AF0038C5 /* TPLHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 3935E1D96EFA691C166637702D92FF1A /* TPLHeader.m */; };
+		CF2B30B1F9601DF0173BB6985F2D9614 /* TPLDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F7F8C383D8F9270A70F9D1CDE49FA9 /* TPLDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CFA8D6B529A0EBFF0316F2629AB2556E /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = EF466BAED148A632F0D86B94710EE5C7 /* AFImageDownloader.m */; };
 		D04B84B53456B9CD8A7236126075571B /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC238BFEC74E3A52A65122EF10679100 /* MobileCoreServices.framework */; };
 		D2A4247F3B0B92D1D67C1C18F4E05371 /* Specta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C6C1BEBCFF500D96751BACC7B72955B /* Specta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D3E1977B4A831F8D6E7FAA5A90E26720 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = C6A45D52E036332B840FDDEE65FD2187 /* SPTSharedExampleGroups.m */; };
+		D4A9A882B54B49140562359C9C865334 /* TPLRequestStructure.m in Sources */ = {isa = PBXBuildFile; fileRef = 790FC873111282F7498BEC62E95639DA /* TPLRequestStructure.m */; };
 		D754C2C15B62D7473C4A6EDC64C66DBF /* RTIvar.m in Sources */ = {isa = PBXBuildFile; fileRef = 75935C78F1DA4FD81E06F4E3928E514B /* RTIvar.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		D83677C54D2226C67886A525B0B46FBE /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 361EAC416B05CB41CB814FDEE8483B46 /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		D85BCB05C5D881668BB7EE5A99DA9B7B /* RTProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 3558F8D47EDEE3265CFC4E49AF263025 /* RTProtocol.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		D8C4AB8AB4D5AEB2A4B19CA938C22CE7 /* TPLHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = B595F2B70FB1E18B79867C3893450E0E /* TPLHeader.m */; };
 		D9F4E833E37B611B432F6B5D7072DDA2 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 17B8B664D44662993E917EB65B9FA97F /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB30F82FB1BE083D9471B965FB500CA2 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DD46F4E92C064ED5D0ADBA027F0BCB9 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DC10E3D4436CBE4952C670687B2216B2 /* Pods-Tropicalytics_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 86BBDF325054136E536E454554BC48BB /* Pods-Tropicalytics_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC730614A2CBBF9F5A07B39021AD0407 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		DD3978D37A597A79B1B7CFE4F577EB31 /* TPLFieldGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = D8525C99DCEF0BD634E74FC6E9E1D669 /* TPLFieldGroup.m */; };
+		DE864C2A9BC7CAB71761B903B1AA2E4A /* TPLConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E1D0FB277F2064A9038865197F27338 /* TPLConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DFFA215EEAA8DDBD540076927535275C /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = D3501FFC901C55619F1B7B16AFC662AC /* AFURLRequestSerialization.m */; };
 		E07FA68FB88EE2F43F6AC94E3F82A248 /* MAObjCRuntime-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03DA11B266BF5D359C253F9B37068B8A /* MAObjCRuntime-dummy.m */; };
 		E0A077DFB064B79685B810CCEFB2F1EF /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A238074057C3C1262FFB1042283E274 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		E0AAF49134A0505DF00E20E7B62087E1 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 24520BAFEECCF3BE67C78D5F333FCFFB /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E0D4045AC4C1B41917FCA23A042D18B2 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 92E102577061A6A34DE8A16029664F04 /* AFHTTPSessionManager.m */; };
+		E1142290E82F582796A978AF0EBA1503 /* TPLEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ACD2E541E203A1137FE38049423684B /* TPLEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1EC4532663CA75DE5BD00CB0A56814D /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DA0DAA45428E3F33D8D501BC58BB542 /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E6300A1DBA3422238070A00D3E737BAF /* TPLDeviceUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = D11AD18C785A4215C9BA50FEA1C2C4AE /* TPLDeviceUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E735386085CE344F6A01178CF4763852 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D075CB92702C3A3ED3494231C01B30 /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E7988678C81F7CCB95D239375FC6986D /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = C83E0E9D4E7A0B0813E910959CD27676 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC7CADE416A78A1CD6936018A6695126 /* AFNetworking-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CF91364B7C2BE28963AAD6111E0343 /* AFNetworking-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECDD35402F533B394ABB08A516155DE5 /* TPLAppUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EDBAF67F6DB06C1E7E554DE0691885F /* TPLAppUtilities.m */; };
 		EE4493053DB8B45C30681D9199FE9E2A /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C61FD5422603B33778B9F4DCC2BFE /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EF6497EE123F6BC0C1B09717437C5908 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C4583AEB3FEB2574EC241C6DFB1A7E7 /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		F09FCC00653002D3E8C1CA1642AAE20F /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 8082CF3EC0D52A8F6187E6DEA1921154 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -209,11 +212,10 @@
 		FACA3A4407CD9E34C76640F7D1601003 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
 		FC20596ABFE14A61F171A29FD03275E7 /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 30F45C340BFE6407CDFCE29A2D7D04DF /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		FC45858927D3B6A0F922C4B697B04A38 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = 1563BDBE9E4EFC68E33D92D0540B58C7 /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FD09294B7074D7B52228F6438A07AD09 /* TPLAppUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CA82626EDA6B9D71108871E9D7399C4E /* TPLAppUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FD161E822D17AB0D171266EFE41F7833 /* Tropicalytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BECD7A1B03527A00FDC7416D15C3DFAD /* Tropicalytics-dummy.m */; };
 		FD2D4497BC41412128C2D87C1BDE7398 /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = A5F065665741190D3660CF916B33C4F0 /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE062E2D92883A1DBD397A9CBC0F60D4 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 30A5BE22737083E2E2C0BBE3AE47944C /* SPTTestSuite.m */; };
 		FE8E34356D24F6759A8B010ED2F5707B /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = C4273C160F01D8F128DEF6AD5469CF7E /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FECC9A63B7F971913EBE3681797C4D13 /* contents in Sources */ = {isa = PBXBuildFile; fileRef = 328BD2C15DAA0C2DBC976405A2EF96E5 /* contents */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -300,30 +302,27 @@
 		01E16264C985F34BC3E5C6833CCAE1C2 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
 		03DA11B266BF5D359C253F9B37068B8A /* MAObjCRuntime-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MAObjCRuntime-dummy.m"; sourceTree = "<group>"; };
 		044A233B0617BF0B3397B312CD619F02 /* Pods-Tropicalytics_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-Tropicalytics_Example.modulemap"; sourceTree = "<group>"; };
+		047288603106E9DC568A16057BDD601F /* TPLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLLogger.h; sourceTree = "<group>"; };
 		07F895A256F1D4DA24CC9DF911735063 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
 		093B510C608944D5C2F42932F5BA6070 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
 		093B78EA86E54DC4F3A1B2F947989BD8 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
 		0A0D6D89A0D6F0ACB4B6E9D469F72CB9 /* Pods-Tropicalytics_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Example-frameworks.sh"; sourceTree = "<group>"; };
 		0C002BF73CF9ED768EC47A919CD0B7B8 /* MARTNSObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MARTNSObject.m; sourceTree = "<group>"; };
 		0C92071F7B076D2F78266367E35DA299 /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
-		0EDBAF67F6DB06C1E7E554DE0691885F /* TPLAppUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAppUtilities.m; sourceTree = "<group>"; };
 		0F4E141AC4C5452BDF7C20C57881C711 /* RTUnregisteredClass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTUnregisteredClass.h; sourceTree = "<group>"; };
 		0F8FD7DFC5C51A6A1598E1A5289BE5CA /* AFNetworking.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = AFNetworking.modulemap; sourceTree = "<group>"; };
-		13488CCDD5B88F0AEA69EB00932D8D5F /* TPLDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDatabase.h; sourceTree = "<group>"; };
-		13A7E9A10DFB5D87FEFDDB08259CFF83 /* TPLDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceInfo.h; sourceTree = "<group>"; };
+		130CC6DB667C8B547C3B579A24E2E256 /* TPLUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUtilities.h; sourceTree = "<group>"; };
 		1415E6307EB1C9AADFD0EE7FAC3B3076 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1498621F79A2955C9783E161A45BF094 /* TPLFieldGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLFieldGroup.m; sourceTree = "<group>"; };
 		1563BDBE9E4EFC68E33D92D0540B58C7 /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
 		161E2A5870AA71357EFB5D3A08330839 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		164545479DF23E9335BF0DA6B8A9F06B /* TPLDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceInfo.h; sourceTree = "<group>"; };
 		1758E125466BAD91C4772A1EE949ADDF /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
 		17B8B664D44662993E917EB65B9FA97F /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
-		17BF2D4F6A1BB77020E36C934D3C7E40 /* contents */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; path = contents; sourceTree = "<group>"; };
 		1858124E2B51C0A1B46A86524BCBC335 /* Specta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Specta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		19EAFD051A6357D7CE67EF4289B99565 /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
 		1A238074057C3C1262FFB1042283E274 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
 		1C374A2B748E32B91C4451F28EC52A41 /* RTIvar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTIvar.h; sourceTree = "<group>"; };
 		1C4583AEB3FEB2574EC241C6DFB1A7E7 /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
-		1C94407A625C4216447458F88047D40F /* TPLRequestManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLRequestManager.h; sourceTree = "<group>"; };
 		1E052C84528CA562DE6AD1FAFB1483E3 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
 		1E8797EDA66E9459C5155CC5750A8543 /* AFAutoPurgingImageCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFAutoPurgingImageCache.m; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.m"; sourceTree = "<group>"; };
 		1EEE2C90C5996C1F017C87D64A2A4BD5 /* Pods-Tropicalytics_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Tests-resources.sh"; sourceTree = "<group>"; };
@@ -332,45 +331,48 @@
 		20FF7AC81EFEBB6E722B793E7EE47F8F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		22C7967C918EC63390360823FB44392D /* Pods-Tropicalytics_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-Tropicalytics_Tests.modulemap"; sourceTree = "<group>"; };
 		2315E4A1E1EA4063E89ABC988B323712 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		234BFF3EA1DD991B98A81BFB561D162F /* TPLRequestManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLRequestManager.h; sourceTree = "<group>"; };
 		237E461836957B621999D3DE5C0FE73C /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
 		24520BAFEECCF3BE67C78D5F333FCFFB /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
 		24978C0D139A516F137BABEAEB5E98A7 /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
 		27272C738519D352C4586A55F5030CEC /* Pods-Tropicalytics_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tropicalytics_Tests-dummy.m"; sourceTree = "<group>"; };
 		2A4D8B739AB877CAEE4AF331A3D61112 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
 		2B83BAEE37ED9AFFCB71B34E701449EB /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
+		2C917F8787CF569EF56457769E018EA1 /* TPLDeviceUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceUtilities.m; sourceTree = "<group>"; };
 		2FA47031DF3A795E8CB1AFB6336BDFF1 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
 		307BBB64F62EB5941021C1482CF822B7 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
 		30A5BE22737083E2E2C0BBE3AE47944C /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
-		30D006D7BFBEB28BA7914E657DDFEB52 /* TPLConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLConfiguration.m; sourceTree = "<group>"; };
 		30F45C340BFE6407CDFCE29A2D7D04DF /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
 		320E4F1C0A54C8EDCDB43A020085444E /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
+		328BD2C15DAA0C2DBC976405A2EF96E5 /* contents */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; path = contents; sourceTree = "<group>"; };
 		32B76F9E3E7B6D0A432ECFFEAE9E2641 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
 		32BB5BC09F3C0D17A752244A07F34C15 /* RTProperty.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTProperty.m; sourceTree = "<group>"; };
 		32FD0E3AEB5A5FA10271509CC6EA3E91 /* Tropicalytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Tropicalytics-prefix.pch"; sourceTree = "<group>"; };
+		3491748A7B4AA117CC8057F27173E36F /* TPLAppUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAppUtilities.m; sourceTree = "<group>"; };
 		3558F8D47EDEE3265CFC4E49AF263025 /* RTProtocol.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTProtocol.m; sourceTree = "<group>"; };
 		35C99CB0B08DF4FA1AC08D1FE3A2940D /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
 		361EAC416B05CB41CB814FDEE8483B46 /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
 		36D802DFF57F88AC97E275EEC3C7C8C4 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3935E1D96EFA691C166637702D92FF1A /* TPLHeader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLHeader.m; sourceTree = "<group>"; };
 		39A8A444600147CF4FD261431427F59F /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
 		3A97EB4033E95E3C23ABCDA4A9BBB023 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
 		3B539990DF3D9D6F061F705BD1AB97CB /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
+		3BB0215F89C0EF6195EC1EF6849B09EC /* TPLRequestStructure.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLRequestStructure.h; sourceTree = "<group>"; };
 		3C0E3F03C9DBBF2623F15B072F8EE4EB /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
+		3E1D0FB277F2064A9038865197F27338 /* TPLConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLConstants.h; sourceTree = "<group>"; };
 		3F5D9459A3E51F32781F3DE3C78A7BC3 /* MAObjCRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MAObjCRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FB73A2F8759492AB49BBF7D89AF63B5 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
+		4060E6112AF11EA38299B83950146E55 /* TPLRequestManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLRequestManager.m; sourceTree = "<group>"; };
 		408A7AF14F4CCE770A8EF0288E3B0F4E /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
 		40D00DFC6A32F78AB78B589250AE2967 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
 		40F2ED78511D7AE9C2C461E14BA0FEDE /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
 		41531956376460ADF9969380716F0F4F /* AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-prefix.pch"; sourceTree = "<group>"; };
 		415E5DB48EDB900698A89CAA7404A890 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
 		419F70664EE5599E7899F5564A80790B /* Pods-Tropicalytics_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Example-resources.sh"; sourceTree = "<group>"; };
-		41AD34E12BBFA99A6B57082122F6016B /* TPLEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLEvent.m; sourceTree = "<group>"; };
 		41C3C6F32FCB975511D64FED50808F68 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
 		41EA7EE51CA28000254601EFA38F3774 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		42962234757A0B0C5FB571FFFCE674FB /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
 		43CF91364B7C2BE28963AAD6111E0343 /* AFNetworking-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-umbrella.h"; sourceTree = "<group>"; };
 		43D8F3D174DE77DE4B86232693B09BD0 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
-		45BF5605466A9EC4C5FFBA9B24630B73 /* Tropicalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Tropicalytics.m; sourceTree = "<group>"; };
 		4663392B2E73D349D33F16F83710E55A /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
 		4747BD40B00A4C264B2D57BB66B42BD0 /* AFImageDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFImageDownloader.h; path = "UIKit+AFNetworking/AFImageDownloader.h"; sourceTree = "<group>"; };
 		480CFE354137A41FA155677A165D6F81 /* RTUnregisteredClass.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTUnregisteredClass.m; sourceTree = "<group>"; };
@@ -378,29 +380,26 @@
 		494EDEFD85B07BAD114515FD56A8E4BF /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
 		4A5D5E394CB2E1B19ED3577784F31F85 /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
 		4AC49A5BFE891F8DB5C468C22951E853 /* Tropicalytics-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Tropicalytics-umbrella.h"; sourceTree = "<group>"; };
+		4CD2D1FD5984A4544E0D7B9124D25819 /* TPLDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDatabase.m; sourceTree = "<group>"; };
 		4D4C8968A88660F583FC622128E2ED22 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
 		4EF3503053D357443A7E767A8610313E /* Pods-Tropicalytics_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tropicalytics_Example-dummy.m"; sourceTree = "<group>"; };
 		5173BEA05027A0482238C295B668F172 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
 		519AED277A8B6E3B62C824D9845B4BDC /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
 		51CD26F32E89ACC67514C52D073B184F /* MAObjCRuntime-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MAObjCRuntime-prefix.pch"; sourceTree = "<group>"; };
 		522503F048F86DB8B3FC6EF36BEBE6BB /* Expecta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Expecta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		551B8CC87D7B16D99AC216293F566DD0 /* Tropicalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tropicalytics.h; sourceTree = "<group>"; };
 		56861037EA61E8AC037C859257B60195 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
 		574875DBC633C280CE29B4C5C92C3B2C /* Pods-Tropicalytics_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Example.release.xcconfig"; sourceTree = "<group>"; };
-		576A4DF39549B36014CADFF3EF76075D /* TPLDeviceUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceUtilities.h; sourceTree = "<group>"; };
-		58311F9E386D1351EC2156550E15D577 /* TPLUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUtilities.h; sourceTree = "<group>"; };
 		5908EB1D8C9A560497B037792FCA3E12 /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
 		5ACE0D0F4A8B882E5F2B903D657E81AE /* MAObjCRuntime.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = MAObjCRuntime.modulemap; sourceTree = "<group>"; };
 		5CD2665763950A3C776E1B07609F9766 /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
-		5D030EA986C2753EE63FC9ECB0524CB7 /* TPLUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUtilities.m; sourceTree = "<group>"; };
 		62B05FDD26E59490F648E62593C27DAB /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
 		635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		65C93B27BBA2E2D35A1F21DB63014370 /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
 		66C43973FE9B62E95CB3E3926B978E49 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
 		66C686FBFB1C276659C7CCC3E6055D1B /* Pods-Tropicalytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		673E0F3028CF6C1C26CF58F579A2096E /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
-		6A4CF28A5A94F30094CE80FB91936AC6 /* TPLConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLConstants.h; sourceTree = "<group>"; };
-		6ADC98DE8770735CA0A60367EBDEDD57 /* TPLBatchDetails.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLBatchDetails.h; sourceTree = "<group>"; };
-		6BB3B9454DCB371FA3386BDCE789AEF0 /* Tropicalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tropicalytics.h; sourceTree = "<group>"; };
+		6ACD2E541E203A1137FE38049423684B /* TPLEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLEvent.h; sourceTree = "<group>"; };
 		6BCC7698FC5E579C04A61927C14ABB1C /* MARTNSObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MARTNSObject.h; sourceTree = "<group>"; };
 		6C28D7A068FD5494806D45CF62CAAE12 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
 		6C6C1BEBCFF500D96751BACC7B72955B /* Specta-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-umbrella.h"; sourceTree = "<group>"; };
@@ -411,6 +410,7 @@
 		6ED102F8589E200C5F73DC52E42CFF9F /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
 		6FF36FE6578030BCCA059AFF12F84F33 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
 		7161B7AF2FB9133556E8B9235C639372 /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
+		71E080A468BB5AB2A2C21E26E63537E2 /* TPLUniqueIdentifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUniqueIdentifier.m; sourceTree = "<group>"; };
 		729EE2B07BC4CE1C4963B64E42594C3B /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
 		72D165B527C6B04FA62635FA695DF34C /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
 		736825C14AB0DC5059B2304F01FCE599 /* Tropicalytics.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tropicalytics.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -419,17 +419,20 @@
 		75935C78F1DA4FD81E06F4E3928E514B /* RTIvar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTIvar.m; sourceTree = "<group>"; };
 		75F1ED3E9BFB58DC6A7AA8AD520C3182 /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
 		760BE70119445BF8B9C8C842A50BEFB6 /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		790FC873111282F7498BEC62E95639DA /* TPLRequestStructure.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLRequestStructure.m; sourceTree = "<group>"; };
 		7A0E1A7B30BD4B8B0D5BCC0423FBA75B /* Pods-Tropicalytics_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tropicalytics_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		7AD57EDC7684E72652BEFB94BCBBB0F3 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
-		7CAE84B93735472042028094A2703C28 /* TPLDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceInfo.m; sourceTree = "<group>"; };
 		7DD46F4E92C064ED5D0ADBA027F0BCB9 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
 		7EFDAEE9BC9F9FD933F7E554804748B0 /* Expecta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Expecta.modulemap; sourceTree = "<group>"; };
+		7F2E1D828EA50853EA092D01F148A539 /* TPLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLLogger.m; sourceTree = "<group>"; };
 		7FEB382CED9092B586EF9D2FCC6CE2D6 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8082CF3EC0D52A8F6187E6DEA1921154 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
 		81A4C6359BEA818EE50CE3AFF5CBF3F8 /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
 		824A89C3ED13835DC40D6AF7EC2093E8 /* MAObjCRuntime-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MAObjCRuntime-umbrella.h"; sourceTree = "<group>"; };
 		82B8E00C315300EDBFDE07086D5F8812 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
 		82DAA1EFED847C2CDE1357092F1FA251 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
+		84AA5CDB9D52805094789EE53A5F1198 /* TPLFieldGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLFieldGroup.h; sourceTree = "<group>"; };
+		84CC80A7E6D99680653564663C3A4BB4 /* TPLBatchDetails.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLBatchDetails.m; sourceTree = "<group>"; };
 		84CF0E427569F2E1E2677C6C75D1A30C /* Pods-Tropicalytics_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		860E8360D18B7E55222AD02C6FA6866C /* MAObjCRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MAObjCRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		861A1063371F50AE8F228277743A826F /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
@@ -442,10 +445,8 @@
 		894C61FD5422603B33778B9F4DCC2BFE /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
 		8BC27F5BB3011BCD928586C46E44B88A /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
 		8DE48683247B727F0F0219645EE1F9F5 /* Pods-Tropicalytics_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tropicalytics_Tests-umbrella.h"; sourceTree = "<group>"; };
-		8FEB7F31DDC5FD6CB74C1CEA3597B455 /* TPLAPIClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAPIClient.h; sourceTree = "<group>"; };
 		91058F81BD0433273EC4438A9174CED0 /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
 		92E102577061A6A34DE8A16029664F04 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
-		95BA1215E0586C731647CD503549C688 /* TPLHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLHeader.h; sourceTree = "<group>"; };
 		964C5C701CA5BE5F3E809764EED57730 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
 		98FFF4E23EBAA35E9CD3C73F34C574A1 /* Pods-Tropicalytics_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		9924A1DA480804CCE203BFF7F4938D30 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
@@ -455,10 +456,11 @@
 		9CBED299A0FBDE512F7165485EF5EE88 /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
 		9CF3B31D6EB40D222FA08270D03DA2BE /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
 		9D12B83609131AA8AB7378C863397150 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9D3BD0BE3B6F01ED6B6EFEA7FB20ED7F /* TPLConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLConfiguration.h; sourceTree = "<group>"; };
+		9D8AF91C67AA77190289868861FF5D35 /* TPLAPIClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAPIClient.h; sourceTree = "<group>"; };
 		9DF866059F140F5989F0BD8B787F534B /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
 		9E7EC431E31C96FE95D4C77B14BA468E /* AFNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AFNetworking.xcconfig; sourceTree = "<group>"; };
 		9F4C09D5ABB3852A4B6BB308211FB888 /* UIImage+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+AFNetworking.h"; path = "UIKit+AFNetworking/UIImage+AFNetworking.h"; sourceTree = "<group>"; };
+		A0580DDE998769BF43C5DF87DD71E9D1 /* TPLHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLHeader.h; sourceTree = "<group>"; };
 		A2698707ECE89224BC884265E7F119A9 /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
 		A2AD7EB4E8714E288666876EFBC00C62 /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
 		A4E58C232854B6285AEF18F572A5C7E2 /* Pods_Tropicalytics_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tropicalytics_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -466,15 +468,21 @@
 		A5F065665741190D3660CF916B33C4F0 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
 		A9F1435AF8F9F903D34031C41619D1D8 /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
 		AA07502408A9CA91389B8D50F3018B7A /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
+		AB59C9F37BE0F0C6919BAF2DBDC4AF0E /* TPLAPIClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAPIClient.m; sourceTree = "<group>"; };
 		AB7AE0EE9DE6B46FF27123DD36EE7656 /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
 		AC3EC58E73C4FD397442C88C140EA6B9 /* RTProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTProperty.h; sourceTree = "<group>"; };
+		AC7F6730CD182DEA662C25BCC89D1B4A /* TPLDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceInfo.m; sourceTree = "<group>"; };
+		ACF940F6BB905B79E5937540D3AAF858 /* TPLConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLConfiguration.h; sourceTree = "<group>"; };
 		AECB9DB0D789BA63A4E2DB48E9F911FD /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
 		AF517D87C43C257FAFED6A2201585887 /* MAObjCRuntime.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MAObjCRuntime.xcconfig; sourceTree = "<group>"; };
 		B0423736FFA88FE8EA2A41E79DC2E601 /* Pods-Tropicalytics_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tropicalytics_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		B0F7F8C383D8F9270A70F9D1CDE49FA9 /* TPLDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDatabase.h; sourceTree = "<group>"; };
 		B0FC275883179BBF9A4E8547B8C41319 /* Pods-Tropicalytics_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		B240313F1B213A37D8975DAC2B614D78 /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
 		B24FD7D9D711C287927C6E7642219553 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		B2E2AA3BD43F0531C251D67BB29CD3D9 /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
+		B595F2B70FB1E18B79867C3893450E0E /* TPLHeader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLHeader.m; sourceTree = "<group>"; };
+		B85934045C854BC4174320093054F76C /* TPLUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUtilities.m; sourceTree = "<group>"; };
 		B905271BF44822792EA48DF27A4B6416 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
 		B91DEF511AAE5AB047AC6233D7FA1AC5 /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
 		B9398525D563222C3D2BEAF9AF2F8A1B /* Specta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Specta.modulemap; sourceTree = "<group>"; };
@@ -487,7 +495,6 @@
 		BECD7A1B03527A00FDC7416D15C3DFAD /* Tropicalytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Tropicalytics-dummy.m"; sourceTree = "<group>"; };
 		BF8A5D5FD78116FFAE774939DB19CE7D /* Tropicalytics.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Tropicalytics.modulemap; sourceTree = "<group>"; };
 		C0E2D7FB534E463EF3F0180767F9BF2E /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
-		C1387C8F2BF159F1425D5CF27EFCB83C /* TPLRequestStructure.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLRequestStructure.h; sourceTree = "<group>"; };
 		C1D32078D598BC895DA140F206554C45 /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
 		C2251CFFE0AEB3F7789BCC2FA0429033 /* Tropicalytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Tropicalytics.xcconfig; sourceTree = "<group>"; };
 		C2D075CB92702C3A3ED3494231C01B30 /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
@@ -496,51 +503,48 @@
 		C6A45D52E036332B840FDDEE65FD2187 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
 		C7AEFEFED9284ADC51610E077D769673 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
 		C83E0E9D4E7A0B0813E910959CD27676 /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
-		CA82626EDA6B9D71108871E9D7399C4E /* TPLAppUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAppUtilities.h; sourceTree = "<group>"; };
 		CAAF695DDD22B3FB18EFDFE29859B1F6 /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
 		CB786BCEFF819325F842A6F68A078C71 /* Tropicalytics.xcdatamodel */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcdatamodel; path = Tropicalytics.xcdatamodel; sourceTree = "<group>"; };
 		CD5EDF0B03235EAC81199D4B695802CD /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
 		CE56C189D1436871EA1BEF1E230581CB /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
 		CEE427098396C593D40404C4677072AB /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D00B1214FB2249B17D63477FC575F1BE /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
-		D262B00A268E742F2278EA07BA8E8A44 /* TPLEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLEvent.h; sourceTree = "<group>"; };
+		D11AD18C785A4215C9BA50FEA1C2C4AE /* TPLDeviceUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceUtilities.h; sourceTree = "<group>"; };
+		D282EF46E30FE460ED014781F69E2986 /* TPLConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLConfiguration.m; sourceTree = "<group>"; };
 		D3501FFC901C55619F1B7B16AFC662AC /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
-		D3B9B3D632038AA99FCE3742E1AE455D /* TPLUniqueIdentifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUniqueIdentifier.m; sourceTree = "<group>"; };
 		D3FD828DDF23CB2D5927E7ADAD3B0FF8 /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
 		D4AA48A433ECB2BBF26BC7A11505F014 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
 		D4C1115012E054B7D6FCC123E9978886 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
 		D5C62B64A0A67B6535BE66A210B01F3D /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
+		D7E2BCFE6849E4F19C28F7CDACE43F0D /* Tropicalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Tropicalytics.m; sourceTree = "<group>"; };
+		D8525C99DCEF0BD634E74FC6E9E1D669 /* TPLFieldGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLFieldGroup.m; sourceTree = "<group>"; };
 		DCA8D189A7F64A2E1EFEB1D492E5C9B0 /* Pods-Tropicalytics_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tropicalytics_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		DDCE0EBDBFD893D8A128BD9507A95CC6 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
-		DE020FB523FB2ED465D9A801433C25C4 /* TPLUniqueIdentifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUniqueIdentifier.h; sourceTree = "<group>"; };
 		DE3064393EAFA98ADCBB0F51F9928D61 /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
 		DED59F076B9E088A6E5F98EB8C00BC86 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
-		DFCE673A37F9BAFA03DB68C1D11B50EA /* TPLFieldGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLFieldGroup.h; sourceTree = "<group>"; };
 		E0311F0CA5EBFD85E51FC577126C74ED /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
-		E23A667DB8C23D87B3D5E5BDD4343FD0 /* TPLRequestManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLRequestManager.m; sourceTree = "<group>"; };
+		E0DE0B6FF0FE3F8D7AC0A6A50829E6CD /* TPLEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLEvent.m; sourceTree = "<group>"; };
+		E260E7130DF3C13D73D7B54E2D171C0F /* TPLBatchDetails.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLBatchDetails.h; sourceTree = "<group>"; };
 		E46DD46C9B83578FA4AB3E4E99AA6060 /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
 		E5F1387418F145763DA282A84C8085F8 /* Pods-Tropicalytics_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tropicalytics_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		E67D9EF3FAE85219A5649B6A3F23E794 /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
 		E6C6D7BC17B35FF9C88A48F86720F247 /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
 		E8883EB79D821E17A15157143B3ABAFF /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E89085B4B3B8B3F1F6AFABC95047B569 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		EB30A65827FC7341E7E0C51169319CE8 /* TPLAppUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAppUtilities.h; sourceTree = "<group>"; };
 		ED5A9AB9707480312760E8FCD2DB7786 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		ED92165F8B9C879DB4610C81E38058A6 /* TPLDeviceUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceUtilities.m; sourceTree = "<group>"; };
 		EE3FAF391B2C5938158F8CCC8BA698BD /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
 		EEC75ACA62ADAEFB0A5D1F782A08BFC4 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
 		EEE020DA7F324BBDC31D5B9A482D6582 /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
 		EF466BAED148A632F0D86B94710EE5C7 /* AFImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFImageDownloader.m; path = "UIKit+AFNetworking/AFImageDownloader.m"; sourceTree = "<group>"; };
-		EFF921E21ED93627AEB75F0A09E30F9C /* TPLDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDatabase.m; sourceTree = "<group>"; };
-		F362A60E0B5E9843ECA5FD436385F51D /* TPLAPIClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAPIClient.m; sourceTree = "<group>"; };
 		F66A3AD5F3C42945C074B85D70D879CB /* Tropicalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tropicalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F709232E06B813FEE808885A22496F5A /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
 		F7C25F11412715116910791D675543C9 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
 		F9EB460416B1C4938820DC263FB509EC /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
-		FC00653319BE88CF47CCD1D46F01737C /* TPLRequestStructure.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLRequestStructure.m; sourceTree = "<group>"; };
 		FC238BFEC74E3A52A65122EF10679100 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
 		FCD3A2AA836ECFC16788AD4653B3C797 /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
+		FCE281B7361F6D285467236E2C55B4F7 /* TPLUniqueIdentifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUniqueIdentifier.h; sourceTree = "<group>"; };
 		FDD6FD00CC0E9A86AD839FFB2434F08D /* AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-dummy.m"; sourceTree = "<group>"; };
-		FF42A4A7268F96C32CA12AC558FB3F28 /* TPLBatchDetails.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLBatchDetails.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -619,6 +623,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		022816B586718BB463E8B8CDC1835FF4 /* UniqueIdentifier */ = {
+			isa = PBXGroup;
+			children = (
+				FCE281B7361F6D285467236E2C55B4F7 /* TPLUniqueIdentifier.h */,
+				71E080A468BB5AB2A2C21E26E63537E2 /* TPLUniqueIdentifier.m */,
+			);
+			path = UniqueIdentifier;
+			sourceTree = "<group>";
+		};
 		02E354557C7B9D0D9BABA163CAB4E367 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -646,15 +659,6 @@
 			name = UIKit;
 			sourceTree = "<group>";
 		};
-		0313FAC961819EC66389D4C6DF0E6866 /* APIClient */ = {
-			isa = PBXGroup;
-			children = (
-				8FEB7F31DDC5FD6CB74C1CEA3597B455 /* TPLAPIClient.h */,
-				F362A60E0B5E9843ECA5FD436385F51D /* TPLAPIClient.m */,
-			);
-			path = APIClient;
-			sourceTree = "<group>";
-		};
 		0576066EFB738D9918051A5CBF34A045 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
@@ -670,6 +674,37 @@
 				85F6D6690EA884E8641ADB15D07827E7 /* Pods-Tropicalytics_Tests */,
 			);
 			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		2A81014DF473EF197ACD09714F137025 /* Tropicalytics.xcdatamodel */ = {
+			isa = PBXGroup;
+			children = (
+				328BD2C15DAA0C2DBC976405A2EF96E5 /* contents */,
+			);
+			path = Tropicalytics.xcdatamodel;
+			sourceTree = "<group>";
+		};
+		2C8271706457536DA3822BEF14B3FBCE /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				EB30A65827FC7341E7E0C51169319CE8 /* TPLAppUtilities.h */,
+				3491748A7B4AA117CC8057F27173E36F /* TPLAppUtilities.m */,
+				D11AD18C785A4215C9BA50FEA1C2C4AE /* TPLDeviceUtilities.h */,
+				2C917F8787CF569EF56457769E018EA1 /* TPLDeviceUtilities.m */,
+				047288603106E9DC568A16057BDD601F /* TPLLogger.h */,
+				7F2E1D828EA50853EA092D01F148A539 /* TPLLogger.m */,
+				130CC6DB667C8B547C3B579A24E2E256 /* TPLUtilities.h */,
+				B85934045C854BC4174320093054F76C /* TPLUtilities.m */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		33A21974881C9BD545BAC2CC73B8957C /* Tropicalytics.xcdatamodeld */ = {
+			isa = PBXGroup;
+			children = (
+				2A81014DF473EF197ACD09714F137025 /* Tropicalytics.xcdatamodel */,
+			);
+			path = Tropicalytics.xcdatamodeld;
 			sourceTree = "<group>";
 		};
 		3C305BB271A82340690BE7BF474FCE73 /* Tropicalytics */ = {
@@ -716,41 +751,21 @@
 			path = Specta;
 			sourceTree = "<group>";
 		};
-		4CE131600B007C4C3C954FA67E85103E /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				6ADC98DE8770735CA0A60367EBDEDD57 /* TPLBatchDetails.h */,
-				FF42A4A7268F96C32CA12AC558FB3F28 /* TPLBatchDetails.m */,
-				6A4CF28A5A94F30094CE80FB91936AC6 /* TPLConstants.h */,
-				13A7E9A10DFB5D87FEFDDB08259CFF83 /* TPLDeviceInfo.h */,
-				7CAE84B93735472042028094A2703C28 /* TPLDeviceInfo.m */,
-				D262B00A268E742F2278EA07BA8E8A44 /* TPLEvent.h */,
-				41AD34E12BBFA99A6B57082122F6016B /* TPLEvent.m */,
-				DFCE673A37F9BAFA03DB68C1D11B50EA /* TPLFieldGroup.h */,
-				1498621F79A2955C9783E161A45BF094 /* TPLFieldGroup.m */,
-				95BA1215E0586C731647CD503549C688 /* TPLHeader.h */,
-				3935E1D96EFA691C166637702D92FF1A /* TPLHeader.m */,
-				C1387C8F2BF159F1425D5CF27EFCB83C /* TPLRequestStructure.h */,
-				FC00653319BE88CF47CCD1D46F01737C /* TPLRequestStructure.m */,
-				6BB3B9454DCB371FA3386BDCE789AEF0 /* Tropicalytics.h */,
-				45BF5605466A9EC4C5FFBA9B24630B73 /* Tropicalytics.m */,
-				0313FAC961819EC66389D4C6DF0E6866 /* APIClient */,
-				A28AC4771B014E30EFEFF6B38EAC98A1 /* Config */,
-				9AB64DC0BB762A4083EB7642FC6B0186 /* Database */,
-				C837F4F35E94ACF97D0494E6E9FDC486 /* Request Manager */,
-				B70F57C1CB3FD3F5825AE56BF7777D01 /* Tropicalytics.xcdatamodeld */,
-				AC51FCAEB60B5D301723EFB092AB7EB0 /* UniqueIdentifier */,
-				6644480307332CCEE1A56D22F9FDF16D /* Utilities */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
 		4EF2BE21F5418278F7ACF4FCEEE50C24 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
 				3C305BB271A82340690BE7BF474FCE73 /* Tropicalytics */,
 			);
 			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		5AFA8B2C419407D3F7D540A3EEF77908 /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				B0F7F8C383D8F9270A70F9D1CDE49FA9 /* TPLDatabase.h */,
+				4CD2D1FD5984A4544E0D7B9124D25819 /* TPLDatabase.m */,
+			);
+			path = Database;
 			sourceTree = "<group>";
 		};
 		5DD6B10CDE4284EE8A0EFA8154CFDBFD /* Security */ = {
@@ -863,19 +878,6 @@
 			path = MAObjCRuntime;
 			sourceTree = "<group>";
 		};
-		6644480307332CCEE1A56D22F9FDF16D /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				CA82626EDA6B9D71108871E9D7399C4E /* TPLAppUtilities.h */,
-				0EDBAF67F6DB06C1E7E554DE0691885F /* TPLAppUtilities.m */,
-				576A4DF39549B36014CADFF3EF76075D /* TPLDeviceUtilities.h */,
-				ED92165F8B9C879DB4610C81E38058A6 /* TPLDeviceUtilities.m */,
-				58311F9E386D1351EC2156550E15D577 /* TPLUtilities.h */,
-				5D030EA986C2753EE63FC9ECB0524CB7 /* TPLUtilities.m */,
-			);
-			path = Utilities;
-			sourceTree = "<group>";
-		};
 		745A9E0954268DB21A3B89D66E70F042 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -901,6 +903,24 @@
 				745A9E0954268DB21A3B89D66E70F042 /* Products */,
 				1B31EDB57B03D10E1F55BE56C8E55A94 /* Targets Support Files */,
 			);
+			sourceTree = "<group>";
+		};
+		833389A7633D5BD876BB4E3498447FFA /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				ACF940F6BB905B79E5937540D3AAF858 /* TPLConfiguration.h */,
+				D282EF46E30FE460ED014781F69E2986 /* TPLConfiguration.m */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
+		83339CDD170C2E559A4F0A204861DB64 /* APIClient */ = {
+			isa = PBXGroup;
+			children = (
+				9D8AF91C67AA77190289868861FF5D35 /* TPLAPIClient.h */,
+				AB59C9F37BE0F0C6919BAF2DBDC4AF0E /* TPLAPIClient.m */,
+			);
+			path = APIClient;
 			sourceTree = "<group>";
 		};
 		85F6D6690EA884E8641ADB15D07827E7 /* Pods-Tropicalytics_Tests */ = {
@@ -932,6 +952,35 @@
 			name = NSURLSession;
 			sourceTree = "<group>";
 		};
+		96B4CE83E3E10474296078FDB74B9CE7 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				E260E7130DF3C13D73D7B54E2D171C0F /* TPLBatchDetails.h */,
+				84CC80A7E6D99680653564663C3A4BB4 /* TPLBatchDetails.m */,
+				3E1D0FB277F2064A9038865197F27338 /* TPLConstants.h */,
+				164545479DF23E9335BF0DA6B8A9F06B /* TPLDeviceInfo.h */,
+				AC7F6730CD182DEA662C25BCC89D1B4A /* TPLDeviceInfo.m */,
+				6ACD2E541E203A1137FE38049423684B /* TPLEvent.h */,
+				E0DE0B6FF0FE3F8D7AC0A6A50829E6CD /* TPLEvent.m */,
+				84AA5CDB9D52805094789EE53A5F1198 /* TPLFieldGroup.h */,
+				D8525C99DCEF0BD634E74FC6E9E1D669 /* TPLFieldGroup.m */,
+				A0580DDE998769BF43C5DF87DD71E9D1 /* TPLHeader.h */,
+				B595F2B70FB1E18B79867C3893450E0E /* TPLHeader.m */,
+				3BB0215F89C0EF6195EC1EF6849B09EC /* TPLRequestStructure.h */,
+				790FC873111282F7498BEC62E95639DA /* TPLRequestStructure.m */,
+				551B8CC87D7B16D99AC216293F566DD0 /* Tropicalytics.h */,
+				D7E2BCFE6849E4F19C28F7CDACE43F0D /* Tropicalytics.m */,
+				83339CDD170C2E559A4F0A204861DB64 /* APIClient */,
+				833389A7633D5BD876BB4E3498447FFA /* Config */,
+				5AFA8B2C419407D3F7D540A3EEF77908 /* Database */,
+				C197FAAF21F730C67381AE10743B4CC7 /* Request Manager */,
+				33A21974881C9BD545BAC2CC73B8957C /* Tropicalytics.xcdatamodeld */,
+				022816B586718BB463E8B8CDC1835FF4 /* UniqueIdentifier */,
+				2C8271706457536DA3822BEF14B3FBCE /* Utilities */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
 		97C190EB5CB86BF601DAC63E0EB96045 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -943,14 +992,6 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		9946B3E678E4AADB5677C9C9ECC966B5 /* Tropicalytics.xcdatamodel */ = {
-			isa = PBXGroup;
-			children = (
-				17BF2D4F6A1BB77020E36C934D3C7E40 /* contents */,
-			);
-			path = Tropicalytics.xcdatamodel;
-			sourceTree = "<group>";
-		};
 		9A478F3954470896B1F7B1DFEA20EFCC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -959,15 +1000,6 @@
 				A0628AC04EC576D1C13F1A0079C57A13 /* iOS */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		9AB64DC0BB762A4083EB7642FC6B0186 /* Database */ = {
-			isa = PBXGroup;
-			children = (
-				13488CCDD5B88F0AEA69EB00932D8D5F /* TPLDatabase.h */,
-				EFF921E21ED93627AEB75F0A09E30F9C /* TPLDatabase.m */,
-			);
-			path = Database;
 			sourceTree = "<group>";
 		};
 		A0628AC04EC576D1C13F1A0079C57A13 /* iOS */ = {
@@ -984,30 +1016,12 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		A28AC4771B014E30EFEFF6B38EAC98A1 /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				9D3BD0BE3B6F01ED6B6EFEA7FB20ED7F /* TPLConfiguration.h */,
-				30D006D7BFBEB28BA7914E657DDFEB52 /* TPLConfiguration.m */,
-			);
-			path = Config;
-			sourceTree = "<group>";
-		};
 		AC38E9A2EAC639FF8F4021DA6969D24F /* Classes */ = {
 			isa = PBXGroup;
 			children = (
 				B7D3CE739FD62D60A1A6C12A25AD624E /* Tropicalytics.xcdatamodeld */,
 			);
 			path = Classes;
-			sourceTree = "<group>";
-		};
-		AC51FCAEB60B5D301723EFB092AB7EB0 /* UniqueIdentifier */ = {
-			isa = PBXGroup;
-			children = (
-				DE020FB523FB2ED465D9A801433C25C4 /* TPLUniqueIdentifier.h */,
-				D3B9B3D632038AA99FCE3742E1AE455D /* TPLUniqueIdentifier.m */,
-			);
-			path = UniqueIdentifier;
 			sourceTree = "<group>";
 		};
 		ADB3D01E7DD2748E858DCEC3BC68E7BB /* AFNetworking */ = {
@@ -1050,14 +1064,6 @@
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Specta";
-			sourceTree = "<group>";
-		};
-		B70F57C1CB3FD3F5825AE56BF7777D01 /* Tropicalytics.xcdatamodeld */ = {
-			isa = PBXGroup;
-			children = (
-				9946B3E678E4AADB5677C9C9ECC966B5 /* Tropicalytics.xcdatamodel */,
-			);
-			path = Tropicalytics.xcdatamodeld;
 			sourceTree = "<group>";
 		};
 		B7B1290F18011342C080DB0770CAE702 /* Resources */ = {
@@ -1128,11 +1134,11 @@
 			path = "Target Support Files/Pods-Tropicalytics_Example";
 			sourceTree = "<group>";
 		};
-		C837F4F35E94ACF97D0494E6E9FDC486 /* Request Manager */ = {
+		C197FAAF21F730C67381AE10743B4CC7 /* Request Manager */ = {
 			isa = PBXGroup;
 			children = (
-				1C94407A625C4216447458F88047D40F /* TPLRequestManager.h */,
-				E23A667DB8C23D87B3D5E5BDD4343FD0 /* TPLRequestManager.m */,
+				234BFF3EA1DD991B98A81BFB561D162F /* TPLRequestManager.h */,
+				4060E6112AF11EA38299B83950146E55 /* TPLRequestManager.m */,
 			);
 			path = "Request Manager";
 			sourceTree = "<group>";
@@ -1160,7 +1166,7 @@
 		E708DE9E605258A4CAF7C6962010B570 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				4CE131600B007C4C3C954FA67E85103E /* Classes */,
+				96B4CE83E3E10474296078FDB74B9CE7 /* Classes */,
 			);
 			path = Pod;
 			sourceTree = "<group>";
@@ -1218,30 +1224,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D092F28EA53CA81B80CB84636B25931 /* Pods-Tropicalytics_Tests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		63677DE1B6F7CCED25951C07976AFCFE /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				503755BC95009E1959B466127718DA50 /* TPLAPIClient.h in Headers */,
-				FD09294B7074D7B52228F6438A07AD09 /* TPLAppUtilities.h in Headers */,
-				1B261CF95B938F1D0008605B106CF1B3 /* TPLBatchDetails.h in Headers */,
-				6EC22B550ECF7AC97B97845FA6D64F76 /* TPLConfiguration.h in Headers */,
-				CCF834C2EFA77D681712D7E80D023FBC /* TPLConstants.h in Headers */,
-				5F9C09A207929B44F9387B3DCF2F8A77 /* TPLDatabase.h in Headers */,
-				5E9CA582E721C549637005F30C784AE9 /* TPLDeviceInfo.h in Headers */,
-				0A73609846EB7600275D5A28D54880CA /* TPLDeviceUtilities.h in Headers */,
-				CEC63042960076B25C3479EA25B3283B /* TPLEvent.h in Headers */,
-				3A640CF561D23145D1452C819704662E /* TPLFieldGroup.h in Headers */,
-				90648186E4DCE8FBC35EF12467573D2A /* TPLHeader.h in Headers */,
-				C486094162F0CE60103DECF13ACB4856 /* TPLRequestManager.h in Headers */,
-				63CEFA7B13F25A41BC8D464D50093C78 /* TPLRequestStructure.h in Headers */,
-				A5A0FA36ED5B6A70AA00971C7EB17D0D /* TPLUniqueIdentifier.h in Headers */,
-				141D68FA80C9DC5B2224318BF1862811 /* TPLUtilities.h in Headers */,
-				9C718EF9D4A9B42767423E4D767BCF68 /* Tropicalytics-umbrella.h in Headers */,
-				51FCCD21A3089CCA665996F22547ED83 /* Tropicalytics.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1318,6 +1300,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E7B4A3B3E99950D52BC94CAD3655D16D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				54A0C3FBD14A988F3D43754CA98D9CAF /* TPLAPIClient.h in Headers */,
+				9D328BF4B14CF5DCC4AD70B5CFA3BE26 /* TPLAppUtilities.h in Headers */,
+				5E9AF174013C55BB85587D7BA855AB72 /* TPLBatchDetails.h in Headers */,
+				2845AFC4EC310D21911987193AE6DC2F /* TPLConfiguration.h in Headers */,
+				DE864C2A9BC7CAB71761B903B1AA2E4A /* TPLConstants.h in Headers */,
+				CF2B30B1F9601DF0173BB6985F2D9614 /* TPLDatabase.h in Headers */,
+				0407E6F6F1E2AEE4C3C9A0A9FA204052 /* TPLDeviceInfo.h in Headers */,
+				E6300A1DBA3422238070A00D3E737BAF /* TPLDeviceUtilities.h in Headers */,
+				E1142290E82F582796A978AF0EBA1503 /* TPLEvent.h in Headers */,
+				359CDFFF69DCE47CA172F6104B2D1C99 /* TPLFieldGroup.h in Headers */,
+				C7A1C0E86C9661BDFC5F63764EB0C7E0 /* TPLHeader.h in Headers */,
+				64F8D0C788524AB5A359D9D2BB50A15C /* TPLLogger.h in Headers */,
+				BD5C86C8C57B375155A3C320E93FC87D /* TPLRequestManager.h in Headers */,
+				55965D7A34B02E6E208A95FF0B22D995 /* TPLRequestStructure.h in Headers */,
+				66289DBD8CACCB555A1C308C07B15753 /* TPLUniqueIdentifier.h in Headers */,
+				162E5BB758F4CB54170B830540787EB3 /* TPLUtilities.h in Headers */,
+				0BECDC96A5E3FF53E85E67C2C8A966C1 /* Tropicalytics-umbrella.h in Headers */,
+				6505040F539B64D37A12448BAD2F0FC3 /* Tropicalytics.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -1359,10 +1366,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 95C0E83C4364C98EA972AAFC120419B3 /* Build configuration list for PBXNativeTarget "Tropicalytics" */;
 			buildPhases = (
-				7C510507152E03F26AA311C05D613037 /* Sources */,
+				10FAAF00CEBBB79BF6CFF2644BFF55B0 /* Sources */,
 				95182BB079148AFF271DF4753F745FB8 /* Frameworks */,
 				2CD1F995B882FA8E9DEA0BF06E2E4DD4 /* Resources */,
-				63677DE1B6F7CCED25951C07976AFCFE /* Headers */,
+				E7B4A3B3E99950D52BC94CAD3655D16D /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1522,6 +1529,31 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		10FAAF00CEBBB79BF6CFF2644BFF55B0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FECC9A63B7F971913EBE3681797C4D13 /* contents in Sources */,
+				22FD653C2E038A549A94103DF8405154 /* TPLAPIClient.m in Sources */,
+				82D0CAC88D65DB9338E1D30540FEE9DB /* TPLAppUtilities.m in Sources */,
+				22D9820B5F9517A438CBF36234D0BFFC /* TPLBatchDetails.m in Sources */,
+				8B61C72CD1E2A9CC1D2047DAF5ECBF4A /* TPLConfiguration.m in Sources */,
+				289AC0D5AD03FFBB201A7A7F634D77F0 /* TPLDatabase.m in Sources */,
+				BFA4AB7B2A09DE80E24FAD21714C45B4 /* TPLDeviceInfo.m in Sources */,
+				CAD1658B88880B4F5417D922D6970902 /* TPLDeviceUtilities.m in Sources */,
+				22F44DF51F618EA55D828D413627BFF5 /* TPLEvent.m in Sources */,
+				DD3978D37A597A79B1B7CFE4F577EB31 /* TPLFieldGroup.m in Sources */,
+				D8C4AB8AB4D5AEB2A4B19CA938C22CE7 /* TPLHeader.m in Sources */,
+				50A23FF732C8451CACE6FBE28C3A5474 /* TPLLogger.m in Sources */,
+				01669FB4803C63BF4BCE00528235D34E /* TPLRequestManager.m in Sources */,
+				D4A9A882B54B49140562359C9C865334 /* TPLRequestStructure.m in Sources */,
+				95231D238DD1A503B6F0F4E7C5BEDEB6 /* TPLUniqueIdentifier.m in Sources */,
+				97DFEBFF82A9ECDAD76CED380BEDD64B /* TPLUtilities.m in Sources */,
+				A8EBD606B6BBECD41DD742AFF4BDA89C /* Tropicalytics-dummy.m in Sources */,
+				87035CF509BAD81C1C2EFC3D22DDF222 /* Tropicalytics.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1F17F426378DF5EC8DFB10304B8C4BA4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1550,30 +1582,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				17EF5B386E320620CDB766CB6AD80700 /* Pods-Tropicalytics_Tests-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7C510507152E03F26AA311C05D613037 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CA9E224E570347EAF99DCE6362875EFD /* contents in Sources */,
-				527EBD9ACF98B1D5DB32C4AB2CBA84EA /* TPLAPIClient.m in Sources */,
-				ECDD35402F533B394ABB08A516155DE5 /* TPLAppUtilities.m in Sources */,
-				45CA647C8D95428293EFEFA28E32F051 /* TPLBatchDetails.m in Sources */,
-				7AF2D65C39AAD532A5C685B09146F5C7 /* TPLConfiguration.m in Sources */,
-				4D48F6B0E27B943FB08C4B239DCC8ADE /* TPLDatabase.m in Sources */,
-				30FDA563476F43403FDD7DFF7C8D7FD4 /* TPLDeviceInfo.m in Sources */,
-				BAB2AA805CA5BC4066BD3E50BE971FC9 /* TPLDeviceUtilities.m in Sources */,
-				AFCD2F24E460A91646724C530026C6B6 /* TPLEvent.m in Sources */,
-				878D7F4E75179B2E9800E12DECE0C166 /* TPLFieldGroup.m in Sources */,
-				CF9B2FFFB9BD02A2AAC06922AF0038C5 /* TPLHeader.m in Sources */,
-				235C61898C33FA8CE7181EB8086EAB52 /* TPLRequestManager.m in Sources */,
-				361FEF17E7327A9901B6F06BA40EB7AC /* TPLRequestStructure.m in Sources */,
-				142B53747754027E796F8A767A9A5823 /* TPLUniqueIdentifier.m in Sources */,
-				06426D5F1959BC83B4546AFF3589C285 /* TPLUtilities.m in Sources */,
-				FD161E822D17AB0D171266EFE41F7833 /* Tropicalytics-dummy.m in Sources */,
-				0DCDA6049704B2AF1DA42EC6D1CFE236 /* Tropicalytics.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Tropicalytics.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Tropicalytics.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'C35A5D39D1D57B7BF85AE213'
+               BlueprintIdentifier = 'FAFB2075DDEF7843D6A5362E'
                BlueprintName = 'Tropicalytics'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Tropicalytics.framework'>

--- a/Example/Pods/Target Support Files/Tropicalytics/Tropicalytics-umbrella.h
+++ b/Example/Pods/Target Support Files/Tropicalytics/Tropicalytics-umbrella.h
@@ -15,6 +15,7 @@
 #import "TPLUniqueIdentifier.h"
 #import "TPLAppUtilities.h"
 #import "TPLDeviceUtilities.h"
+#import "TPLLogger.h"
 #import "TPLUtilities.h"
 
 FOUNDATION_EXPORT double TropicalyticsVersionNumber;

--- a/Example/Tropicalytics/TPLViewController.m
+++ b/Example/Tropicalytics/TPLViewController.m
@@ -14,6 +14,12 @@
 #import <Tropicalytics/TPLRequestStructure.h>
 #import <Tropicalytics/TPLBatchDetails.h>
 
+#ifdef DEBUG
+#define DEBUG_MODE YES
+#else
+#define DEBUG_MODE NO
+#endif
+
 //Leaving this for now because it will help us test things. We will update the ReadMe to explain how to use the Basic Server checked into this project and this
 //will be removed once we are nearly finished with this project.
 static NSString *const urlBasePath = @"http://tropicalyticsresponseserver.herokuapp.com";
@@ -59,9 +65,9 @@ static NSString *const otherBasePath = @"http://localhost:4567";
     [structure addFieldGroup:fieldGroup];
     
     // Initialize the config. This will take care of creating the underlying TPLAPIClient
+    [TPLConfiguration setDebug:DEBUG_MODE];
     TPLConfiguration *config = [[TPLConfiguration alloc] initWithBasePath:[NSURL URLWithString:urlBasePath]];
     config.flushRate = 2;
-    
     config.requestStructure = structure;
     
     self.tropicalyticsInstance = [[Tropicalytics alloc] initWithConfiguration:config];

--- a/Pod/Classes/Config/TPLConfiguration.h
+++ b/Pod/Classes/Config/TPLConfiguration.h
@@ -15,6 +15,23 @@
 @interface TPLConfiguration : NSObject
 
 /**
+ *  Toggles the global debug state of the
+ *  TPLConfiguration. This determines whether
+ *  debug messages are logged.
+ *
+ *  @param debugFlag BOOL whether debug messages are logged
+ */
++ (void) setDebug:(BOOL)debugFlag;
+
+/**
+ *  Returns the global debug state of the
+ *  TPLConfiguration.
+ *
+ *  @return BOOL whether debug messages are logged
+ */
++ (BOOL) debug;
+
+/**
  *  Default Initializer that will create the configuration and the underlying API client.
  *  This will not create a header.
  *
@@ -35,6 +52,7 @@
 @property (nonatomic, readonly) TPLAPIClient *apiClient;
 
 @property (nonatomic, strong) TPLRequestStructure *requestStructure;
+@property (nonatomic) BOOL debug;
 
 /**
  *  Optional: configure how requests are structured.

--- a/Pod/Classes/Config/TPLConfiguration.m
+++ b/Pod/Classes/Config/TPLConfiguration.m
@@ -11,8 +11,17 @@
 #import "TPLAPIClient.h"
 
 static NSUInteger const DefaultFlushRate = 20;
+static BOOL _debugMode = false;
 
 @implementation TPLConfiguration
+
++ (void) setDebug:(BOOL)debugFlag {
+    _debugMode = debugFlag;
+}
+
++ (BOOL) debug {
+    return _debugMode;
+}
 
 - (id) initWithBasePath:(NSURL *)basePath {
     NSParameterAssert(basePath);

--- a/Pod/Classes/Database/TPLDatabase.m
+++ b/Pod/Classes/Database/TPLDatabase.m
@@ -10,6 +10,7 @@
 #import "TPLEvent.h"
 #import "TPLAPIClient.h"
 #import "TPLConstants.h"
+#import "TPLLogger.h"
 
 static NSString *const SQLiteStoreURL            = @"Tropicalytics.sqlite";
 static NSString *const ManagedObjectEntity       = @"Data";
@@ -91,7 +92,7 @@ static NSUInteger const FetchBatchSize           = 50;
     }
     
     if (error) {
-        NSLog(@"Error removing events from queue");
+        [TPLLogger log:@"Error removing events from queue"];
     } else {
         [self saveContext];
     }
@@ -104,7 +105,7 @@ static NSUInteger const FetchBatchSize           = 50;
     NSArray *result = [self.backgroundManagedObjectContext executeFetchRequest:[self fetchRequest] error:&error];
 
     if (error) {
-        NSLog(@"CoreData error %@, %@", error, [error userInfo]);
+        [TPLLogger log:@"CoreData error %@, %@", error, [error userInfo]];
     }
 
     return result;
@@ -128,7 +129,7 @@ static NSUInteger const FetchBatchSize           = 50;
     count = [self.backgroundManagedObjectContext countForFetchRequest:[self fetchRequest] error:&error];
 
     if (error) {
-        NSLog(@"CoreData error %@, %@", error, [error userInfo]);
+        [TPLLogger log:@"CoreData error %@, %@", error, [error userInfo]];
     }
 
     return count;
@@ -157,7 +158,7 @@ static NSUInteger const FetchBatchSize           = 50;
 
     if (self.backgroundManagedObjectContext != nil) {
         if ([self.backgroundManagedObjectContext hasChanges] && ![self.backgroundManagedObjectContext save:&error]) {
-            NSLog(@"CoreData error %@, %@", error, [error userInfo]);
+            [TPLLogger log:@"CoreData error %@, %@", error, [error userInfo]];
         }
     }
 }
@@ -187,7 +188,7 @@ static NSUInteger const FetchBatchSize           = 50;
                                                                         options:nil
                                                                           error:&error];
     if (error) {
-        NSLog(@"error: %@", error.localizedDescription);
+        [TPLLogger log:@"error: %@", error.localizedDescription];
     }
     return managedObjectContext;
 }
@@ -218,7 +219,7 @@ static NSUInteger const FetchBatchSize           = 50;
     if (![fm fileExistsAtPath:[url absoluteString]]) {
         [fm createDirectoryAtURL:url withIntermediateDirectories:YES attributes:nil error:&error];
         if (error) {
-            NSLog(@"Can not create Application Support directory: %@", error);
+            [TPLLogger log:@"Can not create Application Support directory: %@", error];
         }
     }
 

--- a/Pod/Classes/Request Manager/TPLRequestManager.m
+++ b/Pod/Classes/Request Manager/TPLRequestManager.m
@@ -11,6 +11,7 @@
 #import "TPLDatabase.h"
 #import "TPLBatchDetails.h"
 #import "TPLEvent.h"
+#import "TPLLogger.h"
 #import "TPLConfiguration.h"
 #import "TPLRequestStructure.h"
 
@@ -75,12 +76,11 @@
     
     [self.requestStructure setEvents:[self.database getEventsAsJSONFromArray:self.batchEvents]];
     
-    //For debugging.
-    NSLog(@"Post with Parameters:\n%@", [self.requestStructure dictionaryRepresentation]);
+    [TPLLogger log:@"Post with Parameters:\n%@", [self.requestStructure dictionaryRepresentation]];
     
     self.outstandingDataTask = [self.apiClient postWithParameters:[self.requestStructure dictionaryRepresentation] completion:^(NSDictionary *response, NSError *error) {
         if (error) {
-            NSLog(@"Error flushing payload");
+            [TPLLogger log:@"Error flushing payload"];
         } else {
             [self.database removeEventsFromQueue:self.batchEvents];
             self.outstandingDataTask = nil;

--- a/Pod/Classes/Tropicalytics.m
+++ b/Pod/Classes/Tropicalytics.m
@@ -12,6 +12,7 @@
 #import "TPLConfiguration.h"
 #import "TPLUtilities.h"
 #import "TPLHeader.h"
+#import "TPLLogger.h"
 #import "TPLEvent.h"
 #import "TPLRequestManager.h"
 #import "TPLDatabase.h"
@@ -68,6 +69,8 @@ static Tropicalytics *_sharedInstance = nil;
         
         self.requestManager = [[TPLRequestManager alloc] initWithConfiguration:configuration];
         self.requestManager.flushRate = configuration.flushRate;
+        
+        [TPLLogger setEnabled:[TPLConfiguration debug]];
     }
 
     return self;
@@ -111,14 +114,14 @@ static Tropicalytics *_sharedInstance = nil;
 #pragma mark - Selectors
 
 - (void) didEnterBackgroundCallBack:(NSNotification *)notification {
-    NSLog(@"App didEnterBackground");
+    [TPLLogger log:@"App didEnterBackground"];
 
     // Start or finish sending the current batch. Then pause everything since are in the background.
     // We we can get more fancy and add some "didReceiveRemoteNotification" to send analytics for notifications outside of the batching
 }
 
 - (void) willEnterForegroundCallBack:(NSNotification *)notification {
-    NSLog(@"App willEnterForeground");
+    [TPLLogger log:@"App willEnterForeground"];
 
     [self.requestManager flushQueue];
 
@@ -126,7 +129,7 @@ static Tropicalytics *_sharedInstance = nil;
 }
 
 - (void) willTerminateCallBack:(NSNotification *)notification {
-    NSLog(@"App willTerminate");
+    [TPLLogger log:@"App willTerminate"];
     // We probably won't have enough time to kick off a network call so lets store
     // everything and then on the next open send everything off.
 }

--- a/Pod/Classes/Utilities/TPLLogger.h
+++ b/Pod/Classes/Utilities/TPLLogger.h
@@ -1,0 +1,34 @@
+//
+//  TPLLogger.h
+//  Pods
+//
+//  Created by Brett Bukowski on 1/28/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TPLLogger : NSObject
+
+/**
+ *  Returns whether logging is enabled.
+ *
+ *  @return BOOL whether logging is enabled
+ */
++ (BOOL) enabled;
+
+/**
+ *  Sets whether logging is enabled.
+ *
+ *  @param enabledFlag BOOL whether logging is enabled or disabled
+ */
++ (void) setEnabled:(BOOL)enabledFlag;
+
+/**
+ *  Logs the formatted message if logging is enabled.
+ *
+ *  @param format String format and any number of sprintf-substitution arguments
+ */
++ (void) log:(NSString *)format, ...;
+
+@end

--- a/Pod/Classes/Utilities/TPLLogger.m
+++ b/Pod/Classes/Utilities/TPLLogger.m
@@ -1,0 +1,37 @@
+//
+//  TPLLogger.m
+//  Pods
+//
+//  Created by Brett Bukowski on 1/28/16.
+//
+//
+
+#import "TPLLogger.h"
+
+static BOOL _enabled = YES;
+
+@implementation TPLLogger
+
+NSString *const prefix = @"TPL: ";
+
++ (BOOL) enabled {
+    return _enabled;
+}
+
++ (void) setEnabled:(BOOL)enabledFlag {
+    _enabled = enabledFlag;
+}
+
++ (void) log:(NSString *)format, ... {
+    if (!_enabled) {
+        return;
+    }
+    
+    va_list args;
+    va_start(args, format);
+    NSString *fullFormat = [prefix stringByAppendingString:format];
+    NSLogv(fullFormat, args);
+    va_end(args);
+}
+
+@end


### PR DESCRIPTION
Adds TPLLogger class:
- Adds TPL prefix to logged messages
- Provides an `enabled` flag so that callers can configure an instance (or global shared instance) to _not_ log but continue to call log messages, which simply no-op
