### PR TITLE
Resolves #27 #28 #29: Resolves Tests for Core Data, Networking and Creating an Event

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,1407 +7,1320 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		02EE5D844540CEBAF8673966 /* TPLUniqueIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = ECFF2B0F995DD579E33A6684 /* TPLUniqueIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		056B7DD13B3F4C729FDE9716 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B6E8F52C410627D6CCE0780 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		058A61443BDD2224E8EAD706 /* TPLUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EDFB63C4724400C15D80BE /* TPLUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		05B4637AE966844CA97772A0 /* TPLDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F6ACD9C60B05C27481AD288 /* TPLDatabase.m */; };
-		0627959C385A70ADD8902F14 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B73FFFA0625FA531FA599 /* SPTTestSuite.m */; };
-		093351E005568BF0FA11777B /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 36D59E204DFED60F9EDAD3B0 /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0BB45BC75A6FC91057949F0A /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C2C1D6D2854A25A06D3D0B /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		0C3E038B7EAFA5CFDA27ADF9 /* AFNetworking-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AB068E87846BAF7695C205A2 /* AFNetworking-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0CEE09D4EC7ED0A43D3338D1 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FE671B3FA4CEF1B7B7488E5 /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0D26EC8CE675DBE050161BB6 /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = B0CC1EB89334CED2AA17A338 /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		0F086340CC987F003CA20279 /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = F97B6B05FDC9C58D3FC7FD2F /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F344222BC9A2B41DA0F0226 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FE4227B8173725CD2B112A8 /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		11B8720804CA4C75D2C51404 /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EC96A7157C64ADB966C005D /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1250A6246828A95D911AB82B /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = B3BF0AF3ED1E29F5D050C387 /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		128D231839E4F3235E91E943 /* MARTNSObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A612BBEBE21D482C527BF88 /* MARTNSObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1440513A97436C4923381D29 /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 566E6BF0E03A7EB9CF90D1D4 /* Specta-dummy.m */; };
-		14807A6CDAF38A1D4DA7E9F3 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFE53A21749E040B0A1F61B /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		152AA45FAAFF34E9870EEA38 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8611F39B654CFEA26FCA8D /* AFURLRequestSerialization.m */; };
-		15F11CCB60D2054B40E30E50 /* MAObjCRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C357168F5311B6A832333B65 /* MAObjCRuntime.framework */; };
-		1779872CD95E17F9C81C9DD7 /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 24241EC3B511496E7152C871 /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		17E08527CAE68D0EF114D3A0 /* RTProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E7BED9A79E623C377FEAE0B /* RTProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		181D4EFC9EC584AFEF544EB2 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA9B05EF14363EB9A43FF0C1 /* MobileCoreServices.framework */; };
-		197590488A2B936E4D890B58 /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = 4616C2ED7145D11FDD51CB8A /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1CA1876F4ADC44D49F626782 /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A44D442A8C29880368CE3CA /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1DD03553F59B2774903A735F /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = EFF67D24A44348E86C62A187 /* AFSecurityPolicy.m */; };
-		1DF711C01ADC8661FAA070A7 /* RTIvar.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F74B5C2712EC1D97D9E8C3 /* RTIvar.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1FD11FD0AEDA68573C6BBA27 /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B23A9F4B1F82D717702E6F0 /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2317A16916CFF242B20ABA54 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B63D9CC7198CB373B2D25F2 /* AFHTTPSessionManager.m */; };
-		23E1E921FD137D1856CA7AD1 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = DBADCF031E3A7B1698939172 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		241E1090BA19D89EEBA0D73D /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 67602D34B5FDFC1E00A1BDA2 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		24FCD0B7B3989164E5BDFDDA /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BD0B4501FD5DE811F3014B6 /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		280708F7C8BA5065E3F5F9F1 /* TPLConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D83A32FC2C4A2B0FFBB1586 /* TPLConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2885A6C75D33FE480D4A5428 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 680CA0770B720BA4C9CD2F41 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2947D19064F65320BC364B4D /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 805BFACA7D7BF937F045481A /* UIImageView+AFNetworking.m */; };
-		2C579E66B64D000BDD78FAAF /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC3FA7EA4BF57D6AD056F0F /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2DD6291617A3F05AC8D82492 /* TPLDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EAAB4C2F45E64522DFED3E4 /* TPLDeviceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2DEE6CE1E116061DD71558E0 /* RTProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F178181CF9AFC7CFC7D7322 /* RTProtocol.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		2DFA7C7D4BAB3365FD626164 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBB7D4F10D4F9DF16DEB236B /* CoreGraphics.framework */; };
-		30F6086CF96A8DF8C53CD90E /* MAObjCRuntime-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 663983A6EC3B773D48CC5846 /* MAObjCRuntime-dummy.m */; };
-		316634BD1099A53F22246904 /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BDC38B8FA6C7554D45572E9D /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		31AEDA77CEF1135DD1E36557 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AD365A0C24AA4EF0BFE8FD3 /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		339DCB3304D18DE0F62F8305 /* AFNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CF87848F8610CD8AFE260C80 /* AFNetworking-dummy.m */; };
-		33BD4F03450067C3C3CFD701 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B4B88470623347DF8E8E5 /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3632FAED8FD7536DCD0B1E67 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0835853FCB6A303AFD30F660 /* Foundation.framework */; };
-		376C669BB6856EFABAA90FF7 /* TPLBatchDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = C13B712F2C99C95CE0B7E64A /* TPLBatchDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		378B9767A7319A87C393B3AB /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F7B782295DD49D307445211 /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		38CD428160025386FAF921D6 /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 4740A2F17E245C9CDE02EBAB /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		3A6E3CD118809157B91CB2BE /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EF1A61194C1B510BAB1E729 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		3A8AF6F36002CC9A750D788B /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = A128BEF7F74A4EEB7FAB14D0 /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3AB7C3CEC2DB6BF4C18C6F23 /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2B330871B8E867D239E4E8 /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		3CA5A14DA11CD9A390EDC982 /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 26532C970F94CD4745741EC3 /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		3D387D5C23A90EC765FC1F54 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A758CD9237CFBD2A5DB28AF /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3DCCC3D674E44F9574DFCF4D /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 997BBC9CAB5C513CDDFF47D3 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3FC91667EBDFA264C605A873 /* TPLDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F14F6FDF0DC1FD567543DF47 /* TPLDeviceInfo.m */; };
-		40BE52741CD9A7E66421556C /* Pods-Tropicalytics_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B32ECCD74F6B513B2F5002 /* Pods-Tropicalytics_Tests-dummy.m */; };
-		40F8DD028674197F6A4E2CCA /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0BDF66B02A9E6A5A12A1AE /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		41824E118024B17B9D2C4015 /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F7C88071169F039744F47B6 /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		41E7614A4C4F719D707B24B8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0835853FCB6A303AFD30F660 /* Foundation.framework */; };
-		4279D3D3A84DD46E16083AE4 /* TPLAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 896D21F7E54C90AA28B3C9C4 /* TPLAPIClient.m */; };
-		435A79D2A1805B20C070CF45 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D4BF1C89779AB8D8CD5C57B /* Expecta-dummy.m */; };
-		476BC9E1F94FC56B7352CD13 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BBBBAD93A45C160E8815637 /* SPTCompiledExample.m */; };
-		49528D65D0D4547C71B7B3B8 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = B1AF206D12B17E2E4785EE0B /* SpectaDSL.m */; };
-		49B30041048561CEF1EAEC1A /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E43E53703EF200DE9B006A /* SpectaUtility.m */; };
-		49C48575D0C8BFC6D9FEF382 /* TPLHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 33B2C32CED973C3B00D9A285 /* TPLHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49DABA58DA4B4E269214DF12 /* Expecta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B3A585ABC8C12DEB4AEBEB /* Expecta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4A304B4D22ADF94D63B14AA8 /* RTMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = A2CDFE712A611A8561EF6FF1 /* RTMethod.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4AF5AC664E03C77837573F2A /* TPLEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 011F57642DCE843A4C73BF9D /* TPLEvent.m */; };
-		4C18C7BE7540A2D7D00DED06 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 1953BB817695539E365D4A2F /* UIProgressView+AFNetworking.m */; };
-		4C5971BD5BB3660DE59DA319 /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 78EBF49E29858794DFA1B00B /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		518C9DFA997EFAF20A1542DE /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = DA577FC582254B4F55528543 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		51FCCE5C72734B3606C9708F /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 456F0512D9F6FDF4A284118C /* CoreData.framework */; };
-		5518C43275A7D142094F9467 /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D87D0F333C18576CEA44D7 /* SPTCallSite.m */; };
-		55DAE6EA4E7563435E904EC7 /* Pods-Tropicalytics_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F2F7F6CD08ED82222BEEFF64 /* Pods-Tropicalytics_Example-dummy.m */; };
-		57254D2B9B30C4725C0BE6B5 /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 54DF6FDED2050E924CD8937E /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58CE7B77423B11B5C2257C1B /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F11C13F2805B175829181F /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		59DBC14E1DC5B8D8F67789C2 /* TPLDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4FA85592547A761132F313 /* TPLDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A04AF57E4A6ACEEF10EA47F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0835853FCB6A303AFD30F660 /* Foundation.framework */; };
-		5CD05AB2A994AE0940918660 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C61DABE4F0CA3386900F38 /* SPTSpec.m */; };
-		5EF95D55C34E5CEC7344B0C3 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = FC6CD67E3FF2827F47E61CE9 /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5F2B7EDA050A9B8A9655C5F1 /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 70596B7CED927C124E2DC32D /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		62FB84498D0C842CDB1BB4A7 /* TPLBatchDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = D632081029E3C14EBEFCD84D /* TPLBatchDetails.m */; };
-		647CC9E5C65F7776DBC4A10B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0835853FCB6A303AFD30F660 /* Foundation.framework */; };
-		67F9D799C25CC66B030B19A9 /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E7BD51892DA4CDF048B6578 /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6869759896488955785C1ED7 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D2B678351E0D73A7C559902 /* UIActivityIndicatorView+AFNetworking.m */; };
-		6884F6D75A194677DF9F106E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0835853FCB6A303AFD30F660 /* Foundation.framework */; };
-		6C7D8B3FE8AD7BC85096EF64 /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EAAC9E9A9BFC2CAA45D0F30 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D496F354BB4EE1C95B778E3 /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B5DAB6263F944EADCCB1E0B3 /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6DCBA87E171E13440D7C4092 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A585BED58FFC22D394D6645 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6F326303534A55CDCC5D4C7E /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5141B7F7FC247AA928E3EE8F /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		71559A36DF45943FE3DF6A58 /* TPLAppUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 25087426B87159887C8DB805 /* TPLAppUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		721D0897FD809CCAD8CEB8DF /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 986938D8BBB685F57B4E49A7 /* SystemConfiguration.framework */; };
-		7330E612F1F01ABB6A220CCC /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DBF6687B23A6937124E289B /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		73BDB5994044B72C226E400B /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C103BBAEC8839CBB13ED6FBB /* AFURLSessionManager.m */; };
-		73C09D5A01CC91BDE7FAFAC7 /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 41C7DC0BE4689DB6E836040F /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		75C438C001E474B1C9DCBD99 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = D70EEE0F84953D326186080D /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7747C73060E9E2F071DDDEC8 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = C01E875452718AAE01C726C2 /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		781A6E6FF0BE081DB88E5A63 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 464D3CD22B42A6285C4AD91C /* UIRefreshControl+AFNetworking.m */; };
-		795DD6B08D6369C660E7BD97 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = FCE53783B7A851C7787C2976 /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7B4C57D4F4269965FBAF385C /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 84ACE762DF816605DD792765 /* SPTExample.m */; };
-		7CCDB781E1008042A0A8D860 /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 1469BB282440C7D2A38B942D /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7D2BD6C36E94928494FCEF6E /* Tropicalytics.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E78EA460EFD8BA9241DCCA56 /* Tropicalytics.bundle */; };
-		7E1B6C2F76E7B76CD94E329E /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = C8E6726C922AA7D632E2B6D3 /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7E99FEEE1417C10C9CCA45A2 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = E7434050AC818983B34B8E30 /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8073FA0DA56A4E801B5F554C /* TPLUniqueIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = F542FB0AB288ED588CB8EE70 /* TPLUniqueIdentifier.m */; };
-		826A58B59A7F3595575C4CED /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C3583087CBDCA96B96D9E3F /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		82A753A120047D77A55D0D43 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 37B065BBB6523FE9B1F8E10B /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8360DE581CC521CF79BA3658 /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 25CDB7945C023404CEEF5B29 /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		84D99C0B61E73119FAE1025D /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E9D35DF76902C02C23F51C46 /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8712716F65C7E6FA1BBA5456 /* Tropicalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 487B9DF1F7659F3DA0F4373B /* Tropicalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		88CBCF20D64B60780E529366 /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 525E1FDB7BCEED3C3E19C4A5 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AE22680CE8E4DFEFB0F55B2 /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 3189D712631A6E84025EDC22 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8BCF01FB1C5B205600ED876E /* TPLConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCF01FA1C5B205600ED876E /* TPLConstants.h */; };
-		8C56E3C71D3B56CA0A9E6AE8 /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3F8083872F8DDB4A326CF3 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8D623417321B2243EABED62D /* TPLAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 76F494A81E03B23A95B192C5 /* TPLAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		934A1938E158486A4D8DA0AC /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = FF89B40E1C81C216876BFD4F /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9384A1EA0BE4E8E050801EFC /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 910C046E69AEEBA66DF74648 /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9601E08089C105C40D1F6061 /* Tropicalytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3962CF5050EBE8CA3299BB3B /* Tropicalytics-dummy.m */; };
-		960E6A7C800214C17FC3E16C /* Tropicalytics-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 60BF5DB5E8210AAC8C2889E7 /* Tropicalytics-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		96780802415FD6B22A19E792 /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC8BFB195F0887A62085703 /* AFImageDownloader.m */; };
-		99CD20FF6B0A191DA3A2DB88 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B6DC751895CF5C228DF8618 /* SPTSharedExampleGroups.m */; };
-		99E7AEAC017AC626D849D70B /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DE6B8D9A1C241EFFB9D23DE /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		9A1A5BA25FD7ED5A13371A27 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 2939B9E1537A58CEC9F3282D /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A2496E900860885C69C218F /* TPLRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E752C67574484C1E2C074746 /* TPLRequestManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A4D08E675946FBEA740170E /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = DA58047B5C03BB8E71D63823 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A6A47BCC9A8B6E5BEA990EC /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1427D83717625673C0A1AEFD /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		9D6224B9A81E4EBCDAB79CF8 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = FC226BB352A8418B4DCB839B /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A0A68206644823DA66AD79C3 /* RTUnregisteredClass.m in Sources */ = {isa = PBXBuildFile; fileRef = 177E1FC3A550E5B8A4ADFDC1 /* RTUnregisteredClass.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A1837871382CEF86D83FE0EE /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5485900F678E43AF34E68C /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A39764BEBE7F8B60D5641F5E /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F3C7C2DE621E4CC313B61 /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A53A4345D0EFEFE92E2E9503 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = DF5D304B9F727B7F78A86132 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A5507844E83D04ACD8720C86 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8917C6A8541B64650D67B2D8 /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A59683C8276D2D24DC6ED5D9 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F6F257054533FA29119C7D /* XCTestCase+Specta.m */; };
-		A60D57D64D21A2FBB520E304 /* TPLFieldGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = BE0AF38F373EBD721FBE9DED /* TPLFieldGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A6438E6BCD88379CED7F6419 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B1ADEEB26CF0E7F2E92148B /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A7C644B889C64CA44B60F320 /* TPLDeviceUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B9D79E81444B10EE26E6858 /* TPLDeviceUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A96F4B9C1FA6FEA0D692ECE2 /* Pods-Tropicalytics_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 77A66F090B984C6897B8D430 /* Pods-Tropicalytics_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB1DA5551DD012FA23D37791 /* RTProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = BD470CD919162C44CFAC94E0 /* RTProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB7AB19AC31BB726254ACF85 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C56F976358846A2937E887A1 /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		ABA0EEFE007B82165947377E /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 39FB31A57E282FD7D871DDA1 /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AC36ED0055C3BEB0511989AF /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = C9844118A441FB6F0DBDF6E5 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		AD36E1C96C491A74B360490A /* RTIvar.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F90B73F8BB62B021E5A7C65 /* RTIvar.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AF5859CD39CCBF05B22D008A /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A996B6892DBB909CBB07E78 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AFD58BE89DE7BEA830A0BFB6 /* TPLDeviceUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 26E77000308C33F4EEF3B78B /* TPLDeviceUtilities.m */; };
-		AFFEB547694ECCB37DD2F4BF /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DB3AF35C0B48F0B4E641E34 /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3AF6A826FA227A8B11D38D9 /* MARTNSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = B7166B393D2F1466234EBDE4 /* MARTNSObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3CE9C99D45D37DD6B945502 /* RTUnregisteredClass.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CE2DE2777957FF438C1C6B /* RTUnregisteredClass.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B5D8BAA534B2632923F4ADCD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0835853FCB6A303AFD30F660 /* Foundation.framework */; };
-		B5FECFDC215717DA90D42AB8 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A55EB69AAF998F134584F7 /* Security.framework */; };
-		B7CD90AC422EA97CB79DB66C /* Tropicalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 434263D8CB3C13123AEB293B /* Tropicalytics.m */; };
-		BB2577CF155F9E58F2FCAED3 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D53DCF7E4F3D76B22A720A /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BCDD78432A5AB27A5B2F4430 /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = 08947A5715EB758FC8090AFF /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BEDC89ED6A7023C1599E6844 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = B19DC89501A2EB1FC6B63C48 /* SPTExampleGroup.m */; };
-		BF63081DBD63FF0B152A4CAE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0835853FCB6A303AFD30F660 /* Foundation.framework */; };
-		BF73794C88A61252F1FFE8F7 /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 05DFE5ABEA7809400D01A2B9 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C071573E14F6A12699EB126C /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E92958402F77E4A3A1B838B /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C11EA415E1461999E2D6081C /* AFNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE162C857B9E2F73C6B4D7CB /* AFNetworking.framework */; };
-		C50127F3B6E8C26E0007AAC4 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = A4B152E773A23C111F798586 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C69944832128E0297F97E30D /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E2B2BB83C0233A07964E2110 /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C6B20EEE055241BE8F95508A /* TPLAppUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = DD469BD56006481A5A5CD7F5 /* TPLAppUtilities.m */; };
-		C6D738BF67CFC52D02743E6E /* Specta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 41A8E57A599807B34D423FD0 /* Specta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C6DC2CCC2143FD9C8F24D806 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 02A4D8CADACB136E4A9EB35D /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C825FCB3E9AC004EC2E7E253 /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = DBA579DD23AC5C564FEAEDE0 /* UIButton+AFNetworking.m */; };
-		CA0B5A059398CFBB0716210C /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F28D2F290D6E9BD1686CE3 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		CAF2D63F526FB94C08B64C75 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EBAFF4C99F255B21978DFA6 /* AFURLResponseSerialization.m */; };
-		CE3191927D695F5F688107DB /* TPLFieldGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B1812F4B305CD9D33C1A72 /* TPLFieldGroup.m */; };
-		D05105A05247EE7AEDD236EC /* TPLEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 208A7EDC7F79F4219AFFC096 /* TPLEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D283EE2DA9DB1FA29BB1C6E8 /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = 858A113D5005570A3156446F /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D46E2E902DB724D2ABD71C51 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 369B61EF3CB48FB673F54588 /* UIWebView+AFNetworking.m */; };
-		D5170A96AE044CC8DF87FB8B /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 378474427426D5E2AAD24457 /* AFAutoPurgingImageCache.m */; };
-		D5AACA5306BBB4F20A40A3CD /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B83B094C6BEDE11A946C338 /* AFNetworkReachabilityManager.m */; };
-		D5E0A8D0E1585CDF25731C3C /* Tropicalytics.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = A1BA91204A11F46AD66DAB63 /* Tropicalytics.xcdatamodeld */; };
-		D75EADAAF51082BE44F186D0 /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E98278602C325075C17C41 /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		D8D034D16583D37E17C34222 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 6268E5E47C1501E54CDDAF3A /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D96E1F72977CFD08AECEFAA6 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = E39EB5AE93BDE3228ED3E026 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DB04415BB7941629953F2A21 /* TPLConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = A07DA51FC8B94D21EBCD76F5 /* TPLConfiguration.m */; };
-		DC37A8533021B532383B5171 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D5D53F2DAF996E2DBC7B87E /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DCE56CC457D00834AF488527 /* Pods-Tropicalytics_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 75A42F90C34C50A133525E22 /* Pods-Tropicalytics_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E0E1D1DD1AA8E869F44CB7B3 /* MAObjCRuntime-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 556E0171217F7F57C60C774F /* MAObjCRuntime-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E0E510ED902CEA9CDF509A51 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FBFE4DFEEC20ED6C90A6B34 /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E151FBC46A903249245AFC18 /* TPLHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A1820E358E26588DA5AB22 /* TPLHeader.m */; };
-		E2E789A028BB92B8E351E239 /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 104705BD0F59239E950FF932 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E3180D70318AFD838FACFE47 /* TPLRequestManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 909F47FCF0AEB50D97E3334A /* TPLRequestManager.m */; };
-		E44C58BD141ACDF5FA588E21 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = FFC91C789B9C2BC425794D66 /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E52116BD73445D097B684DA8 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 733955116C1B15ECA12EC5BF /* XCTest.framework */; };
-		E60E8C28363A214699F7B694 /* TPLUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = CCD5F6D4A3A753BB795EDCF6 /* TPLUtilities.m */; };
-		E703A751F305B05070F99985 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C4B111709923DD89239A38A8 /* AFNetworkActivityIndicatorManager.m */; };
-		E77ACCD76B94932DF054F481 /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B67D483F588048CA6509168 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E7CC7C077BA1ADAD0DE14AC7 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 49A897FC3A2F4F68D00DCCCB /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EAFA6AAC94C49B30F53BD2A8 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 46C5C220234C54D9CD68B1DD /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		EDF7118AF1E0ECA3A4A871EA /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = EEEB876B4DDABF6126CE34DD /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F0AC18D774E52FB27F0AEB7E /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = 67FC358DBD87EEEBF6C9A36F /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F1BA9CEB54D79AC77B7156D7 /* RTProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = CD665009199C76A30BD8AEF3 /* RTProperty.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F1CE4D94F69D0D09D927C2EF /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F984F119FDD273A3D68CDB /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F20C788E5B9929B537A664B2 /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = D53B877D0A19E2094582A8AC /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F290B8B5520999D48C128BC3 /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = 95F725B2E54499F16B6A74A8 /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F45D6ED8583D3B61F106D71E /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = CF7ED9918505382834E5152B /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F4CB18F57912B6BD917941EC /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A6AB1F67E410F9862D16A1 /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F5E8D6BC15D7DEB6EAEE884D /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = BFD4042AC08F1AC1FD8037C5 /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F831DC40F99709F044C0AC27 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 733955116C1B15ECA12EC5BF /* XCTest.framework */; };
-		F8FB0DDA33255623634A06B8 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 509E906421BBDD824171F348 /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FA02E63B6C365FA887C3B580 /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = ABA3474637645056E72F1AFD /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FB37F1DD5F11E37C3D767FCE /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 48D69F531C8EC48F2E3BF627 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FC8E9F69D55776B4C93D1C21 /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 95732E99024A5AA921F8A5E4 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FC97F17129269651E642A806 /* RTMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = FB79B4B12177402334AFC706 /* RTMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01FDB9509628825F65A36D617903EA60 /* RTUnregisteredClass.m in Sources */ = {isa = PBXBuildFile; fileRef = 480CFE354137A41FA155677A165D6F81 /* RTUnregisteredClass.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		021186FE99D6975FAE757AC8E46558D1 /* RTProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E41157E661E63C9548727BBE60EE4A1 /* RTProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06071F3814A1707B85A8D74D95B96683 /* TPLDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E7256A26D59AE3CAC26C8D4C479883C /* TPLDeviceInfo.m */; };
+		0A86BDD666FEB55E3276435C816F8B1F /* TPLDeviceUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = EBC8529A48A40CE22A3849E786B4DC2E /* TPLDeviceUtilities.m */; };
+		0C6FF91EB1F0391ED75DC72D31D159EF /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = 673E0F3028CF6C1C26CF58F579A2096E /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0D16B556212D317A0D4FEB71E102E207 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 40D00DFC6A32F78AB78B589250AE2967 /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0EBFA5FBE4953A83B677CE2A75746761 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = B91DEF511AAE5AB047AC6233D7FA1AC5 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0F94F5B0ABB3252B9275B7C129EC7A26 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = EEC75ACA62ADAEFB0A5D1F782A08BFC4 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11C1AEB289C1EB80089349B71F09D04B /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 43D8F3D174DE77DE4B86232693B09BD0 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		12F95AEFF8EB3F9ED139C6D26B9C8264 /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ED102F8589E200C5F73DC52E42CFF9F /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1312A7D381C51428CF481E33E3D37901 /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = D4AA48A433ECB2BBF26BC7A11505F014 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		131532787AD40BE1F35DF288D2E6FFD7 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 91058F81BD0433273EC4438A9174CED0 /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1480F4923DBBF217F60572EEECB4027C /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3FAF391B2C5938158F8CCC8BA698BD /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		160FDA46EE919AAF97E0E4EC04C9E232 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		164B2A363F9B0096A792A69320A30D42 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = DDCE0EBDBFD893D8A128BD9507A95CC6 /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		174202BD6AE0E4A41F5CE66E975EAE52 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E052C84528CA562DE6AD1FAFB1483E3 /* UIRefreshControl+AFNetworking.m */; };
+		17572374B2AE183C6347C41E8DF8E579 /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 87662EBF42E6FAD0E92226F8163E2E5B /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		17EF5B386E320620CDB766CB6AD80700 /* Pods-Tropicalytics_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 27272C738519D352C4586A55F5030CEC /* Pods-Tropicalytics_Tests-dummy.m */; };
+		1A1AB2EC52323C5EA28DAA99F1E1A90D /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 885C7DBB171E6DEEAA643351A6772262 /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1AB3304B6884F626BC54150AC7565E18 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D5E394CB2E1B19ED3577784F31F85 /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1B0389CD88AA949B34DC7269030FEC6F /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4C8968A88660F583FC622128E2ED22 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1B4583D6E68B3C76C754D57835707F89 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20FF7AC81EFEBB6E722B793E7EE47F8F /* XCTest.framework */; };
+		1E5B8F12ED7CC40ECDB9B1F755F387E5 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CBED299A0FBDE512F7165485EF5EE88 /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		201BF9C605852822CA5A65ADE282A310 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CD5EDF0B03235EAC81199D4B695802CD /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		204D694B03BFF3B244A6AB73FACFFC43 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E46DD46C9B83578FA4AB3E4E99AA6060 /* Expecta-dummy.m */; };
+		20607BE2B1E5F31765026E5AC64DB27D /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = C7AEFEFED9284ADC51610E077D769673 /* AFSecurityPolicy.m */; };
+		20EE8030FCF2402DAC7F1C9B9DDAEF79 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 093B510C608944D5C2F42932F5BA6070 /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2343A10BA5F34DBCEAF0C4D7AA6CA951 /* TPLAppUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 66CFDC007CF7F0BC40864E603BB4A6F2 /* TPLAppUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23500E6D25DA1901837F20BB447C21A8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		23DC772ACCF5806AE9CFDA1604FC400C /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = AA07502408A9CA91389B8D50F3018B7A /* SPTCompiledExample.m */; };
+		260BC7EED9289AF321A6F791964CE472 /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 202FF15792933080E43DF6C3BCDFFAFC /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2810F816A41B60EC24C3D882D83AF212 /* RTUnregisteredClass.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4E141AC4C5452BDF7C20C57881C711 /* RTUnregisteredClass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2916A0606136A9DC67F2463AB230868B /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = E0311F0CA5EBFD85E51FC577126C74ED /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C0A8737FDB9B9C6A6BDF437FD11334C /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = C0E2D7FB534E463EF3F0180767F9BF2E /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2CFE2898496C1C7096DB8DA43AF19103 /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = A9F1435AF8F9F903D34031C41619D1D8 /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2D092F28EA53CA81B80CB84636B25931 /* Pods-Tropicalytics_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DE48683247B727F0F0219645EE1F9F5 /* Pods-Tropicalytics_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2E14619153A453BB8DF389FB6EA147BE /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F709232E06B813FEE808885A22496F5A /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2E58192A60F2DC4F7B426B6DAA8F6689 /* TPLEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D914C8F02F68FE6FDED7AC68199CC64 /* TPLEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2E7F13CBDDBD5D1E32FD42D6A99F6EFD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		2E8A32ED46194EDBE22146271F6D26DE /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = E89085B4B3B8B3F1F6AFABC95047B569 /* UIImageView+AFNetworking.m */; };
+		2F427490ACABC4408D57CC0592276678 /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = CAAF695DDD22B3FB18EFDFE29859B1F6 /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		31DE08E2C2F98427FB92272F0888C9C4 /* TPLDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F9920388BF7E9BA120AB890585385BD /* TPLDeviceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3335B1AFA6CE35BCE9EA402F68C18A1B /* TPLDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = C9C5C1888711FD6E2DF19960C63234BF /* TPLDatabase.m */; };
+		33BC013B3C8F98E74D039CB62CBBFBC6 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = D00B1214FB2249B17D63477FC575F1BE /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		341F8F1652A7DE6AADAA3331CA6320CB /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 56861037EA61E8AC037C859257B60195 /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34B6E9A30603BEBBD87BA535B7D384CA /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 32B76F9E3E7B6D0A432ECFFEAE9E2641 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		372F7A9CCE59CE86316CF436F832A3FC /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE020DA7F324BBDC31D5B9A482D6582 /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		37A2D0F8493469EF2495FC689440F079 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 42962234757A0B0C5FB571FFFCE674FB /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		397B320B7C59C168CC5B62E18ED8DEA0 /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = DED59F076B9E088A6E5F98EB8C00BC86 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A10EF6ABF51D1D00B06AC5EF3A8C28C /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41EA7EE51CA28000254601EFA38F3774 /* SystemConfiguration.framework */; };
+		3A31EDB6BCFB40F2DE1A3A68A6071960 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 729EE2B07BC4CE1C4963B64E42594C3B /* XCTestCase+Specta.m */; };
+		3A36886057E5A931014ACC66023B8431 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 093B78EA86E54DC4F3A1B2F947989BD8 /* CoreData.framework */; };
+		3B57335169177F4A558D98236BD8D38A /* Tropicalytics.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 736825C14AB0DC5059B2304F01FCE599 /* Tropicalytics.bundle */; };
+		3B5B7495707BF7133B9FB3F834045611 /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C1D32078D598BC895DA140F206554C45 /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C2700C7DAA15C6AF84A595865C42F4D /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = B905271BF44822792EA48DF27A4B6416 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D2789FC760A97301909F0B1201626CD /* AFNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FDD6FD00CC0E9A86AD839FFB2434F08D /* AFNetworking-dummy.m */; };
+		3F1BC9BAFFEEABB1ABC7614DF0FC97D5 /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E8797EDA66E9459C5155CC5750A8543 /* AFAutoPurgingImageCache.m */; };
+		403292D82DA62291204BF59524BC4EDB /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 24978C0D139A516F137BABEAEB5E98A7 /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		40583F11C8BEB933BFC82864F7C2869C /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD3A2AA836ECFC16788AD4653B3C797 /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		42483EECCC29200E3295EAFD4E1738E8 /* TPLRequestManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 474AF8A86F5D81BFBA1AAC0698EA3A5E /* TPLRequestManager.m */; };
+		46137F5CC368BF38BAF0D0AF81DD8FFE /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D165B527C6B04FA62635FA695DF34C /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		471FD4F68E27AB26FA2AEBB8B245CEE4 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 41C3C6F32FCB975511D64FED50808F68 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		494767D9F1B586F1F97BF993498F002F /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D5C62B64A0A67B6535BE66A210B01F3D /* Specta-dummy.m */; };
+		4ACEDCD4909C909CD15AACCC43A7B089 /* TPLConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EA05AB0CAD50D3EF236ACBE26B429DD /* TPLConfiguration.m */; };
+		4BBCBB9D8EF0B241A4A4FE4982985481 /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 66C43973FE9B62E95CB3E3926B978E49 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		51DDDB0FB4899757CF6A826B531B940D /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 867D9AF4FF470DA68D363C120DB72FA6 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		536293D7AF840017A21EC63E1B811A2E /* MARTNSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BCC7698FC5E579C04A61927C14ABB1C /* MARTNSObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		553B6989768B187B16B1E127D813AE20 /* RTIvar.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C374A2B748E32B91C4451F28EC52A41 /* RTIvar.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		560698A4D707DCBCC1C8F98BC9B89B23 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BD8DA0F7C54949412A8BA81A6DCDDF99 /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		57C82EC703961B78511B46C6EEBB70A7 /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B539990DF3D9D6F061F705BD1AB97CB /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5808B477EFF509D810B5CDCFDC944F80 /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 4747BD40B00A4C264B2D57BB66B42BD0 /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		59876AFB4A82B77A0FCC8CDB2A7FEBF4 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = A2AD7EB4E8714E288666876EFBC00C62 /* SpectaUtility.m */; };
+		599298371E33787177EF97722CF48412 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = B240313F1B213A37D8975DAC2B614D78 /* SpectaDSL.m */; };
+		59F17B09B955685C482CCFEA106D81B1 /* TPLHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 56153DFCF729A0275377DD7B9F669E07 /* TPLHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2D4A621D3DA971A474776AF36BB073 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 74134635D078692BF3F5DEFB39EC00DD /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5BAD8306315E116F6E8E76552EC5B665 /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = ED5A9AB9707480312760E8FCD2DB7786 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BFF41C4949CA8CB6BAA45B2754D96A6 /* TPLUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = BC0CB761C4BB4E20B22FF6E4DC06F449 /* TPLUtilities.m */; };
+		5CD5F64603D7BAC8072AB6F4936C30F9 /* TPLDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = D8E869FEDAEF2E552F5461B57AFD21B1 /* TPLDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5EA7043FE10E75D02F3C3052AF8B8318 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = A51AFA314793A1C7F3DF89A27FD7CAF6 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5FF6453E55785669885F626B853FD2AA /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA47031DF3A795E8CB1AFB6336BDFF1 /* UIProgressView+AFNetworking.m */; };
+		6095B07F1C2B84B967C0A5CE012C0EBA /* TPLConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = BD208BA9B66F9E1B71802D78A04F7A54 /* TPLConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60E3009342BEE96D32C546BE2DB60052 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 07F895A256F1D4DA24CC9DF911735063 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		659960F7E28E993E08CCC1E8A383E710 /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 5173BEA05027A0482238C295B668F172 /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65BC31095CCDFC80CBF6BBA843751F23 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 237E461836957B621999D3DE5C0FE73C /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66A27898E989A3FA5C15AA671C4536F0 /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 307BBB64F62EB5941021C1482CF822B7 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6712C24A9D9DFFDCEAB6BAF3D5B0EB8A /* TPLConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = AFD1A4872CB7470298D32DC943DB40CC /* TPLConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67459AD239EF669A365519E06B45DCFE /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 82DAA1EFED847C2CDE1357092F1FA251 /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68152D921ABF6A423C192C04FDF94F0F /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BAE57C33490B0B1AF6088B01E11F886A /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		689D42AF6D9D42F36E2E31CDC25978B7 /* RTMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E8E503534AB88BE13BAE3C1E9D9577B /* RTMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A38977EBAE334DC3C22386D00D2622 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 62B05FDD26E59490F648E62593C27DAB /* AFNetworkReachabilityManager.m */; };
+		6C3940612920F2F97069AF6AAF4BDAFD /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 519AED277A8B6E3B62C824D9845B4BDC /* SPTExample.m */; };
+		6E1D978790705E137FDE439AA68DD3AA /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF866059F140F5989F0BD8B787F534B /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6ED4ABEE8A5F51F5ECB59FA1781D29C6 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 890B11D7D6F4BFBEECD999A94E27A786 /* UIActivityIndicatorView+AFNetworking.m */; };
+		6EFC63A5CED45BB39FC79D87F2C47D6B /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F73FBFCCE22E56C194C05BE1638EB59 /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F278423C8AE1DA47F35E374BB5B91EC /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CD2665763950A3C776E1B07609F9766 /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		707B1A7541C8DBDDE8C27896A61370BE /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AB7AE0EE9DE6B46FF27123DD36EE7656 /* AFURLSessionManager.m */; };
+		7332F15718920917F544F35CE2C038AA /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A97EB4033E95E3C23ABCDA4A9BBB023 /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74EF67DE380915006A15DD206DBB3A6E /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 82B8E00C315300EDBFDE07086D5F8812 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		76CCABE79C04444450153424D7CE1DC1 /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 861A1063371F50AE8F228277743A826F /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		76D337327C10A7555447B69AA1562647 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C99CB0B08DF4FA1AC08D1FE3A2940D /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		770CAD284D566918F2623C2E034000B3 /* Tropicalytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BECD7A1B03527A00FDC7416D15C3DFAD /* Tropicalytics-dummy.m */; };
+		78A09642B8D3048606BCE3CDC2019071 /* RTProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = AC3EC58E73C4FD397442C88C140EA6B9 /* RTProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79558B1F97ABE4AB8942DC18BEBD4B82 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E2AA3BD43F0531C251D67BB29CD3D9 /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A211860F672261C1522DCDF1FFC9ED0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20FF7AC81EFEBB6E722B793E7EE47F8F /* XCTest.framework */; };
+		7B223B4E6EF14BA12DA113F7EE10B96C /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 5908EB1D8C9A560497B037792FCA3E12 /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7C2D978E5E9C044BADB8BAFA2E30A3E6 /* Tropicalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 72030FC356763407445C4C16E26E804B /* Tropicalytics.m */; };
+		7E3542B8B4D6B017C763EA83D1FA9293 /* TPLAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 70EFBB03414DEA461DE88C7569E67966 /* TPLAPIClient.m */; };
+		7E6A4EFA32969CDB9F9C57903152BA54 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A33BF6D48242005A5EE8B489B416344 /* CoreGraphics.framework */; };
+		7F17EA5E2787B6F2BBB359854B42A0E3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		805E425BBEF7A6133E32E1D30A073010 /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = D3FD828DDF23CB2D5927E7ADAD3B0FF8 /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		81B617F8D26BB10C5726D75E85D21EB7 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 760BE70119445BF8B9C8C842A50BEFB6 /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81E0DB04CED585BE1AF0A843A1EFDEAE /* MARTNSObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C002BF73CF9ED768EC47A919CD0B7B8 /* MARTNSObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		837B593D7C1D01B4EA400247309D6AB0 /* Expecta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AAE48B66D04BFE93C713663A4CD3643 /* Expecta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		85E31076D5530AEEB45ACF16B2B8A983 /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A4D8B739AB877CAEE4AF331A3D61112 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		85EB2F216487CB2E8F3FCCFBC4D69912 /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = E6C6D7BC17B35FF9C88A48F86720F247 /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8633BE2B6F523A83EDCAFAB77EBC4AD3 /* RTProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = 32BB5BC09F3C0D17A752244A07F34C15 /* RTProperty.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		87E76C70F7F2EE1EE2AAE992DD63B9F1 /* Tropicalytics-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AC49A5BFE891F8DB5C468C22951E853 /* Tropicalytics-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87FD5F0F682CDEB6A348CA448889E3EA /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = F9EB460416B1C4938820DC263FB509EC /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		884E62C59DCFD8F1FBF4B3F3324BE069 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		8C8C1B0D83FE6A4352F15154DB16372C /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 4663392B2E73D349D33F16F83710E55A /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DC751D799A71AA97FD7F5DE1A171210 /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD57EDC7684E72652BEFB94BCBBB0F3 /* SPTCallSite.m */; };
+		8F3C7283335959E7FBFD25BDC7B376CD /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = CE56C189D1436871EA1BEF1E230581CB /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		918E06480F28F27361B19D19432F8538 /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 9924A1DA480804CCE203BFF7F4938D30 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		931D410B9F8ACB935883DF8C59F9C93E /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C92071F7B076D2F78266367E35DA299 /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9436299B947A7E6B7474EEB264505FE3 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 40F2ED78511D7AE9C2C461E14BA0FEDE /* SPTExampleGroup.m */; };
+		94C47C87E397972CE98F75929F3B706C /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 65C93B27BBA2E2D35A1F21DB63014370 /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		950B9F547AD949C32ABE5F20C8FDDD2F /* contents in Sources */ = {isa = PBXBuildFile; fileRef = A8C8BD49A285284CD8ACC1CC30EA3D08 /* contents */; };
+		995A898987821ED94ACC9FB6BE68293D /* TPLDeviceUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 051F7B71A3B263FB817CEEA3E2DB351F /* TPLDeviceUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B2E761A064459F77EA9870BEF03ACC3 /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E16264C985F34BC3E5C6833CCAE1C2 /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B913DE1C355BCE97D2EDA90D3AA5FC1 /* TPLUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E8FC18849F34F6ECC95656E05CE29D0 /* TPLUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9BB9159FBA757600D3D4C0FF645F3911 /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 408A7AF14F4CCE770A8EF0288E3B0F4E /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9D70C9E416B6F71AE612A42465CB6D39 /* TPLFieldGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = A4B4272766A9E7112FE2C1938F60E1E4 /* TPLFieldGroup.m */; };
+		9E1E90DED74B73ECE53C9AD76DE53E2D /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4C09D5ABB3852A4B6BB308211FB888 /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A09327D92920BB0EDF8F2B97249FC997 /* TPLEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = C67017CE1BD11A06E84EA27AB3D291F3 /* TPLEvent.m */; };
+		A1D998E7B4EF6598D2163CC1BF72BF97 /* TPLUniqueIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FC29AF9978E2F882A5D65EB11ABDA9C /* TPLUniqueIdentifier.m */; };
+		A462945883F7729B185B64B679A6BFBE /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CCD624B009530E994DF7F1F347DBF70 /* UIWebView+AFNetworking.m */; };
+		A55368BBDD7417464F40151C5F9B6A09 /* MAObjCRuntime-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 824A89C3ED13835DC40D6AF7EC2093E8 /* MAObjCRuntime-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A6C6019D45BE62C61210A9CC619368EF /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 415E5DB48EDB900698A89CAA7404A890 /* AFNetworkActivityIndicatorManager.m */; };
+		AB39AC9746E7575D7449700475E41B0B /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C4DF160A02BC4D99EB5BF20C1B9E1C37 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC9BA05FC3672457AD6AC317D2A819F9 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C28D7A068FD5494806D45CF62CAAE12 /* SPTSpec.m */; };
+		AE2A07407FB50BA249984DC0620E84C0 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C1115012E054B7D6FCC123E9978886 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF03C11A1FAC8132AD3749D8F541701A /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 1758E125466BAD91C4772A1EE949ADDF /* UIButton+AFNetworking.m */; };
+		AF1F46668D4591602887998C6E9C10AD /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BC27F5BB3011BCD928586C46E44B88A /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AFFC8900E52BBEC72059334132F3A8F3 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 81A4C6359BEA818EE50CE3AFF5CBF3F8 /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B05DD383D9D1887FD8F83A8D7415A095 /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = AECB9DB0D789BA63A4E2DB48E9F911FD /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5852322ADE88AAD56EE042B80BA81E4 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 320E4F1C0A54C8EDCDB43A020085444E /* AFURLResponseSerialization.m */; };
+		B84431CF8C64F363A334AA7089F6C134 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 39A8A444600147CF4FD261431427F59F /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BA12B131F10BCE3BE6E9A02FC908FE9D /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C25F11412715116910791D675543C9 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BC55C8365AEFF8217F6A567607754854 /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FB73A2F8759492AB49BBF7D89AF63B5 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BEFFE9FFE52E9A0833A7D2D8FB67EB4D /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = E67D9EF3FAE85219A5649B6A3F23E794 /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C00782B6CD46D9EB56C5F8DBD892DC93 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 161E2A5870AA71357EFB5D3A08330839 /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C01AC3BAD9037A8A1E45FD17336C15F3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B24FD7D9D711C287927C6E7642219553 /* Security.framework */; };
+		C2CF0EB220F8F42DF5398D53B0AE5A0C /* AFNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2315E4A1E1EA4063E89ABC988B323712 /* AFNetworking.framework */; };
+		C2DD28375E1F0B1D0D1D2E4E607C499F /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B83BAEE37ED9AFFCB71B34E701449EB /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C453B6E83975F6663D3F1C33CB3B5E03 /* TPLUniqueIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F3FB804742793E24AB40997E3EBB8ED9 /* TPLUniqueIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6354FEC7728A4C86DAD8092509BA7D4 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BD0820FED0B34F7C4C4F85F5A9093331 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C782AC36CFE36AA4324D41C0B4EB0310 /* RTMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = BC298EF491113D68B9F125ED633F3073 /* RTMethod.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C834C57C115A6D9667B7296B80C019E2 /* Tropicalytics.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = B7D3CE739FD62D60A1A6C12A25AD624E /* Tropicalytics.xcdatamodeld */; };
+		CAC483EF637FB4A2C2E2FC75BA631B87 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 19EAFD051A6357D7CE67EF4289B99565 /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CBB5E3ADE44538D569D63A9FF7003BB4 /* Pods-Tropicalytics_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EF3503053D357443A7E767A8610313E /* Pods-Tropicalytics_Example-dummy.m */; };
+		CE3F4ECBB0BC095577D66AE50C8E604C /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 964C5C701CA5BE5F3E809764EED57730 /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		CE7416A504B2D1121091BEED0F07EA75 /* MAObjCRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860E8360D18B7E55222AD02C6FA6866C /* MAObjCRuntime.framework */; };
+		CFA8D6B529A0EBFF0316F2629AB2556E /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = EF466BAED148A632F0D86B94710EE5C7 /* AFImageDownloader.m */; };
+		D04B84B53456B9CD8A7236126075571B /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC238BFEC74E3A52A65122EF10679100 /* MobileCoreServices.framework */; };
+		D095DAFFC0228BEB9473245C48AC2C86 /* TPLBatchDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = D52DB94783212DD28C11307030370DFE /* TPLBatchDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D2A4247F3B0B92D1D67C1C18F4E05371 /* Specta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C6C1BEBCFF500D96751BACC7B72955B /* Specta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3E1977B4A831F8D6E7FAA5A90E26720 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = C6A45D52E036332B840FDDEE65FD2187 /* SPTSharedExampleGroups.m */; };
+		D754C2C15B62D7473C4A6EDC64C66DBF /* RTIvar.m in Sources */ = {isa = PBXBuildFile; fileRef = 75935C78F1DA4FD81E06F4E3928E514B /* RTIvar.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		D83677C54D2226C67886A525B0B46FBE /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 361EAC416B05CB41CB814FDEE8483B46 /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		D85BCB05C5D881668BB7EE5A99DA9B7B /* RTProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 3558F8D47EDEE3265CFC4E49AF263025 /* RTProtocol.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		D9F4E833E37B611B432F6B5D7072DDA2 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 17B8B664D44662993E917EB65B9FA97F /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB30F82FB1BE083D9471B965FB500CA2 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DD46F4E92C064ED5D0ADBA027F0BCB9 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DC10E3D4436CBE4952C670687B2216B2 /* Pods-Tropicalytics_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 86BBDF325054136E536E454554BC48BB /* Pods-Tropicalytics_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC702B3EA680EFEBC472A1E0AC8C07DD /* TPLAppUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C8D525080DB3346BD6FCE77CE9789155 /* TPLAppUtilities.m */; };
+		DC730614A2CBBF9F5A07B39021AD0407 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		DFFA215EEAA8DDBD540076927535275C /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = D3501FFC901C55619F1B7B16AFC662AC /* AFURLRequestSerialization.m */; };
+		E07FA68FB88EE2F43F6AC94E3F82A248 /* MAObjCRuntime-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03DA11B266BF5D359C253F9B37068B8A /* MAObjCRuntime-dummy.m */; };
+		E0A077DFB064B79685B810CCEFB2F1EF /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A238074057C3C1262FFB1042283E274 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E0AAF49134A0505DF00E20E7B62087E1 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 24520BAFEECCF3BE67C78D5F333FCFFB /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E0B6A9C0D66D2EB745DC11B08236C1B1 /* Tropicalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = D9D475117EC54B7ECA993740AFB82D17 /* Tropicalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E0D4045AC4C1B41917FCA23A042D18B2 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 92E102577061A6A34DE8A16029664F04 /* AFHTTPSessionManager.m */; };
+		E1EC4532663CA75DE5BD00CB0A56814D /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DA0DAA45428E3F33D8D501BC58BB542 /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E69E67C39F4340EE7690A1110217B7AA /* TPLAPIClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FDE9573171D7AC8BBF2C7DD9DEF907 /* TPLAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E735386085CE344F6A01178CF4763852 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D075CB92702C3A3ED3494231C01B30 /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7988678C81F7CCB95D239375FC6986D /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = C83E0E9D4E7A0B0813E910959CD27676 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC7CADE416A78A1CD6936018A6695126 /* AFNetworking-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CF91364B7C2BE28963AAD6111E0343 /* AFNetworking-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE4493053DB8B45C30681D9199FE9E2A /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C61FD5422603B33778B9F4DCC2BFE /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF6497EE123F6BC0C1B09717437C5908 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C4583AEB3FEB2574EC241C6DFB1A7E7 /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F09FCC00653002D3E8C1CA1642AAE20F /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 8082CF3EC0D52A8F6187E6DEA1921154 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F0DDF02A078B917997FF025BB33BB842 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7426C29FF85B6E36B03DACAE7EEC492A /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F12A0C603FDA2FDECB63BE324E043ED7 /* TPLRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 129291D583AF85C58E9D5336C8110C60 /* TPLRequestManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F12D57414A73406831CC032A7170DBFF /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FF36FE6578030BCCA059AFF12F84F33 /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F37470070FB9192B6923FB2ADCF5C6D7 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 7161B7AF2FB9133556E8B9235C639372 /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F41209A94070904A00BDF24ACB6336B6 /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = 494EDEFD85B07BAD114515FD56A8E4BF /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F6F9E850AF0799AEC46391604D5254E0 /* TPLBatchDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FCE5230B87A0E4745AF4A6106015F45A /* TPLBatchDetails.m */; };
+		F75CB2A727F678C9A848A3A11EA7979B /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CF3B31D6EB40D222FA08270D03DA2BE /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F845FE027C41B7FF67C2BACDC16CC23E /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 75F1ED3E9BFB58DC6A7AA8AD520C3182 /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FACA3A4407CD9E34C76640F7D1601003 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */; };
+		FC20596ABFE14A61F171A29FD03275E7 /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 30F45C340BFE6407CDFCE29A2D7D04DF /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FC45858927D3B6A0F922C4B697B04A38 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = 1563BDBE9E4EFC68E33D92D0540B58C7 /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FD2D4497BC41412128C2D87C1BDE7398 /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = A5F065665741190D3660CF916B33C4F0 /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD9C6838BA7084DACC934D868AA0D388 /* TPLHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DC9C6CA0D0BB185FA3F0CDF859C823F /* TPLHeader.m */; };
+		FE062E2D92883A1DBD397A9CBC0F60D4 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 30A5BE22737083E2E2C0BBE3AE47944C /* SPTTestSuite.m */; };
+		FE635A989AD51FDD5A957911BE281527 /* TPLFieldGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F782B9DEA7183C5D0ACF08414A92205 /* TPLFieldGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FE8E34356D24F6759A8B010ED2F5707B /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = C4273C160F01D8F128DEF6AD5469CF7E /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0C281E642DE54C7006A787C4 /* PBXContainerItemProxy */ = {
+		0D9B966EE00FFBFA5606C789C8ACA3FB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 901977407F28FD34ED7BD7ED;
-			remoteInfo = AFNetworking;
-		};
-		25ABC5DEFDF95185163910E2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 901977407F28FD34ED7BD7ED;
-			remoteInfo = AFNetworking;
-		};
-		5B1ED5CFB9DB1DC0B5B54A67 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 901977407F28FD34ED7BD7ED;
-			remoteInfo = AFNetworking;
-		};
-		73CED46867DB8A1274BFDB2D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D3505E04070EDD818D3D70A8;
-			remoteInfo = Tropicalytics;
-		};
-		795E33A724C334E9DA8D1B18 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CA2488A6AAF184795C789D52;
-			remoteInfo = Expecta;
-		};
-		AFE9B7E8156E6ECA63190F2B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A4CA4C94B10CA708DEC0F48B;
-			remoteInfo = MAObjCRuntime;
-		};
-		B5C1420571AD582EA3143733 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 344CD463CAA283D595371E33;
-			remoteInfo = "Tropicalytics-Tropicalytics";
-		};
-		C1694B938C6F669A4EB179B9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 555C0DCF4037F17BB7332590;
+			remoteGlobalIDString = D45F1F7801E597113BC0502F5733DC4C;
 			remoteInfo = Specta;
 		};
-		D973371143277DA70D76F2A4 /* PBXContainerItemProxy */ = {
+		39BB80002617237CA403B80B35E590F6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D3505E04070EDD818D3D70A8;
+			remoteGlobalIDString = 0D888F29E05E498D0CD91A51D28599A5;
+			remoteInfo = Expecta;
+		};
+		4023CA49EF33585409708FDCAF2933E3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C3436CEA5C3D39764C5F54374794ECB;
+			remoteInfo = AFNetworking;
+		};
+		560FED28C55799C180CA80BE621DF0BA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C3436CEA5C3D39764C5F54374794ECB;
+			remoteInfo = AFNetworking;
+		};
+		7BB28BB8BC0752CE65CBF028B5E5D7B7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 71A2CBBB6F73FB1925C80B5FA2E5520D;
+			remoteInfo = "Tropicalytics-Tropicalytics";
+		};
+		858EBA66B3F2334C0D88D469C2FCB6C7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2E506988AC2C89E31E46A3E227C81671;
 			remoteInfo = Tropicalytics;
 		};
-		EFFE6BD33B87BBF1FBCC5413 /* PBXContainerItemProxy */ = {
+		A575C8515D32A39D080C06882EBD5D25 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A4CA4C94B10CA708DEC0F48B;
+			remoteGlobalIDString = 9A466F5C83182C5DE3B2448AD24B9B0E;
 			remoteInfo = MAObjCRuntime;
 		};
-		F43886CA6C83797CAE4412C3 /* PBXContainerItemProxy */ = {
+		ADF6E39EC53C18960D24659B91A38FBC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = B2932AAD8FF3E8F5B06C0279 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A4CA4C94B10CA708DEC0F48B;
+			remoteGlobalIDString = 1C3436CEA5C3D39764C5F54374794ECB;
+			remoteInfo = AFNetworking;
+		};
+		F1B72B0E45FDC11C17FF0E2EB42AB284 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A466F5C83182C5DE3B2448AD24B9B0E;
+			remoteInfo = MAObjCRuntime;
+		};
+		F318E5A918DF8C9E5E868836FC36196A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2E506988AC2C89E31E46A3E227C81671;
+			remoteInfo = Tropicalytics;
+		};
+		FE51DC0E12A41E136B41CCD2C9F39376 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A466F5C83182C5DE3B2448AD24B9B0E;
 			remoteInfo = MAObjCRuntime;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		00C61DABE4F0CA3386900F38 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
-		011F57642DCE843A4C73BF9D /* TPLEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLEvent.m; sourceTree = "<group>"; };
-		02A4D8CADACB136E4A9EB35D /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		05DFE5ABEA7809400D01A2B9 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
-		06F900A63FD8EB06FA8C86BA /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
-		071D002A3DD913E005C979C5 /* MAObjCRuntime.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MAObjCRuntime.xcconfig; sourceTree = "<group>"; };
-		0835853FCB6A303AFD30F660 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		08947A5715EB758FC8090AFF /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
-		0AC0FE3EC835E966AD24ED03 /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
-		0B63D9CC7198CB373B2D25F2 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
-		0B83B094C6BEDE11A946C338 /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
-		0E3BAA578BB761F9737F65B2 /* MAObjCRuntime-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MAObjCRuntime-prefix.pch"; sourceTree = "<group>"; };
-		0EC96A7157C64ADB966C005D /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
-		0F7B782295DD49D307445211 /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
-		104705BD0F59239E950FF932 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
-		13B32ECCD74F6B513B2F5002 /* Pods-Tropicalytics_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tropicalytics_Tests-dummy.m"; sourceTree = "<group>"; };
-		1427D83717625673C0A1AEFD /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
-		1469BB282440C7D2A38B942D /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
-		149FB071D5A9B00862C1C10A /* Specta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Specta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		16C68FCC6AFEDA88107C10FD /* Expecta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Expecta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		177E1FC3A550E5B8A4ADFDC1 /* RTUnregisteredClass.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTUnregisteredClass.m; sourceTree = "<group>"; };
-		1866D3FD164CFABAB6940471 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1953BB817695539E365D4A2F /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
-		1A585BED58FFC22D394D6645 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
-		1A996B6892DBB909CBB07E78 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
-		1AC8BFB195F0887A62085703 /* AFImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFImageDownloader.m; path = "UIKit+AFNetworking/AFImageDownloader.m"; sourceTree = "<group>"; };
-		1B6DC751895CF5C228DF8618 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
-		1C1A145E74AE1448BA436275 /* Expecta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Expecta.modulemap; sourceTree = "<group>"; };
-		1C27927ECAFF35F0D646FC77 /* AFNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AFNetworking.xcconfig; sourceTree = "<group>"; };
-		1E7BD51892DA4CDF048B6578 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
-		1F178181CF9AFC7CFC7D7322 /* RTProtocol.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTProtocol.m; sourceTree = "<group>"; };
-		208A7EDC7F79F4219AFFC096 /* TPLEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLEvent.h; sourceTree = "<group>"; };
-		210F3C7C2DE621E4CC313B61 /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
-		24241EC3B511496E7152C871 /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
-		25087426B87159887C8DB805 /* TPLAppUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAppUtilities.h; sourceTree = "<group>"; };
-		25CDB7945C023404CEEF5B29 /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
-		26532C970F94CD4745741EC3 /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
-		26C2C1D6D2854A25A06D3D0B /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
-		26E77000308C33F4EEF3B78B /* TPLDeviceUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceUtilities.m; sourceTree = "<group>"; };
-		28F6F257054533FA29119C7D /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
-		2939B9E1537A58CEC9F3282D /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
-		2A612BBEBE21D482C527BF88 /* MARTNSObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MARTNSObject.m; sourceTree = "<group>"; };
-		2AEA1B6A63F99EA6F986D094 /* MAObjCRuntime.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = MAObjCRuntime.modulemap; sourceTree = "<group>"; };
-		2B23A9F4B1F82D717702E6F0 /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
-		2B9D79E81444B10EE26E6858 /* TPLDeviceUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceUtilities.h; sourceTree = "<group>"; };
-		2C8EF197A0779AFB16F0656D /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		2D1C1FA95148C00B5C0EE315 /* MAObjCRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MAObjCRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2FBFE4DFEEC20ED6C90A6B34 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
-		30D87D0F333C18576CEA44D7 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
-		3189D712631A6E84025EDC22 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
-		33B2C32CED973C3B00D9A285 /* TPLHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLHeader.h; sourceTree = "<group>"; };
-		33EDFB63C4724400C15D80BE /* TPLUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUtilities.h; sourceTree = "<group>"; };
-		369B61EF3CB48FB673F54588 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
-		36D59E204DFED60F9EDAD3B0 /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
-		378474427426D5E2AAD24457 /* AFAutoPurgingImageCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFAutoPurgingImageCache.m; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.m"; sourceTree = "<group>"; };
-		37B065BBB6523FE9B1F8E10B /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
-		381BD6E0206D8212754AD170 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3962CF5050EBE8CA3299BB3B /* Tropicalytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Tropicalytics-dummy.m"; sourceTree = "<group>"; };
-		39FB31A57E282FD7D871DDA1 /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
-		3B6BF98AFCA45F0F075C8B6A /* Pods-Tropicalytics_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tropicalytics_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		3EBAFF4C99F255B21978DFA6 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
-		402B31CD85EDCCFCE6EE6487 /* Pods_Tropicalytics_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tropicalytics_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		41A8E57A599807B34D423FD0 /* Specta-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-umbrella.h"; sourceTree = "<group>"; };
-		41C7DC0BE4689DB6E836040F /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
-		42A3EE8F0250F2618C4C22D3 /* Specta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Specta.modulemap; sourceTree = "<group>"; };
-		434263D8CB3C13123AEB293B /* Tropicalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Tropicalytics.m; sourceTree = "<group>"; };
-		44EB3EFF693546C0A537E5E3 /* contents */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; path = contents; sourceTree = "<group>"; };
-		456F0512D9F6FDF4A284118C /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		4616C2ED7145D11FDD51CB8A /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
-		464D3CD22B42A6285C4AD91C /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
-		46C5C220234C54D9CD68B1DD /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
-		4740A2F17E245C9CDE02EBAB /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
-		487B9DF1F7659F3DA0F4373B /* Tropicalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tropicalytics.h; sourceTree = "<group>"; };
-		48D69F531C8EC48F2E3BF627 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
-		49A897FC3A2F4F68D00DCCCB /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
-		4B1ADEEB26CF0E7F2E92148B /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
-		4B67D483F588048CA6509168 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
-		4C3583087CBDCA96B96D9E3F /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
-		4D5D53F2DAF996E2DBC7B87E /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
-		4E92958402F77E4A3A1B838B /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
-		4F90B73F8BB62B021E5A7C65 /* RTIvar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTIvar.h; sourceTree = "<group>"; };
-		509E906421BBDD824171F348 /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
-		5141B7F7FC247AA928E3EE8F /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
-		525E1FDB7BCEED3C3E19C4A5 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
-		54DF6FDED2050E924CD8937E /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
-		556E0171217F7F57C60C774F /* MAObjCRuntime-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MAObjCRuntime-umbrella.h"; sourceTree = "<group>"; };
-		566E6BF0E03A7EB9CF90D1D4 /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
-		56BF1DB7A734B532096CD190 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		58B1812F4B305CD9D33C1A72 /* TPLFieldGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLFieldGroup.m; sourceTree = "<group>"; };
-		5AD365A0C24AA4EF0BFE8FD3 /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
-		5BBBBAD93A45C160E8815637 /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
-		5BD0B4501FD5DE811F3014B6 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
-		5BFE53A21749E040B0A1F61B /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
-		5D83A32FC2C4A2B0FFBB1586 /* TPLConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLConfiguration.h; sourceTree = "<group>"; };
-		5DB3AF35C0B48F0B4E641E34 /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
-		5DE6B8D9A1C241EFFB9D23DE /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
-		5EAAB4C2F45E64522DFED3E4 /* TPLDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceInfo.h; sourceTree = "<group>"; };
-		5FE4227B8173725CD2B112A8 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
-		60BF5DB5E8210AAC8C2889E7 /* Tropicalytics-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Tropicalytics-umbrella.h"; sourceTree = "<group>"; };
-		61B3A585ABC8C12DEB4AEBEB /* Expecta-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-umbrella.h"; sourceTree = "<group>"; };
-		6268E5E47C1501E54CDDAF3A /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
-		62A6AB1F67E410F9862D16A1 /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
-		65E98278602C325075C17C41 /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
-		65F11C13F2805B175829181F /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
-		663983A6EC3B773D48CC5846 /* MAObjCRuntime-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MAObjCRuntime-dummy.m"; sourceTree = "<group>"; };
-		66F984F119FDD273A3D68CDB /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
-		67602D34B5FDFC1E00A1BDA2 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
-		67FC358DBD87EEEBF6C9A36F /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
-		680CA0770B720BA4C9CD2F41 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
-		6B6E8F52C410627D6CCE0780 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
-		6BDFE707A23940C4E60396BF /* Pods_Tropicalytics_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tropicalytics_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6F83707433D8FD279F42D0F8 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6F8DCF81F3D10E1E334CD666 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		70596B7CED927C124E2DC32D /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
-		733955116C1B15ECA12EC5BF /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		739ACA28B8090F590C00737D /* Tropicalytics.xcdatamodel */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcdatamodel; path = Tropicalytics.xcdatamodel; sourceTree = "<group>"; };
-		7477867ED95A8B5EF55D10E8 /* AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-prefix.pch"; sourceTree = "<group>"; };
-		75A42F90C34C50A133525E22 /* Pods-Tropicalytics_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tropicalytics_Example-umbrella.h"; sourceTree = "<group>"; };
-		76F494A81E03B23A95B192C5 /* TPLAPIClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAPIClient.h; sourceTree = "<group>"; };
-		77A66F090B984C6897B8D430 /* Pods-Tropicalytics_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tropicalytics_Tests-umbrella.h"; sourceTree = "<group>"; };
-		78EBF49E29858794DFA1B00B /* AFImageDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFImageDownloader.h; path = "UIKit+AFNetworking/AFImageDownloader.h"; sourceTree = "<group>"; };
-		7A758CD9237CFBD2A5DB28AF /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
-		7BC3FA7EA4BF57D6AD056F0F /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
-		7D2B678351E0D73A7C559902 /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
-		7D4BF1C89779AB8D8CD5C57B /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
-		7E7BED9A79E623C377FEAE0B /* RTProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTProperty.h; sourceTree = "<group>"; };
-		7EAAC9E9A9BFC2CAA45D0F30 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
-		7EF1A61194C1B510BAB1E729 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
-		7F7C88071169F039744F47B6 /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
-		805BFACA7D7BF937F045481A /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
-		8209EE88A97687B21CB4E32D /* Pods-Tropicalytics_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-Tropicalytics_Example.modulemap"; sourceTree = "<group>"; };
-		84ACE762DF816605DD792765 /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
-		858A113D5005570A3156446F /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
-		8917C6A8541B64650D67B2D8 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
-		896D21F7E54C90AA28B3C9C4 /* TPLAPIClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAPIClient.m; sourceTree = "<group>"; };
-		8A2B330871B8E867D239E4E8 /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
-		8A3B73FFFA0625FA531FA599 /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
-		8A44D442A8C29880368CE3CA /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
-		8BCF01FA1C5B205600ED876E /* TPLConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPLConstants.h; sourceTree = "<group>"; };
-		8DBF6687B23A6937124E289B /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
-		8F6ACD9C60B05C27481AD288 /* TPLDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDatabase.m; sourceTree = "<group>"; };
-		909F47FCF0AEB50D97E3334A /* TPLRequestManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLRequestManager.m; sourceTree = "<group>"; };
-		910C046E69AEEBA66DF74648 /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
-		95732E99024A5AA921F8A5E4 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
-		95F725B2E54499F16B6A74A8 /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
-		96199037BF78A999576FA839 /* Tropicalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tropicalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		986938D8BBB685F57B4E49A7 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
-		997BBC9CAB5C513CDDFF47D3 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
-		9B5485900F678E43AF34E68C /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		9ECD3B87940A157976092A08 /* Pods-Tropicalytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		9FE671B3FA4CEF1B7B7488E5 /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
-		A07DA51FC8B94D21EBCD76F5 /* TPLConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLConfiguration.m; sourceTree = "<group>"; };
-		A128BEF7F74A4EEB7FAB14D0 /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
-		A1D53DCF7E4F3D76B22A720A /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		A2CDFE712A611A8561EF6FF1 /* RTMethod.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTMethod.m; sourceTree = "<group>"; };
-		A4B152E773A23C111F798586 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
-		AB068E87846BAF7695C205A2 /* AFNetworking-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-umbrella.h"; sourceTree = "<group>"; };
-		ABA3474637645056E72F1AFD /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
-		AD2A1D02AF7B57563074447F /* Pods-Tropicalytics_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		AE9B6AEF7F634172B137BFBD /* Pods-Tropicalytics_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-Tropicalytics_Tests.modulemap"; sourceTree = "<group>"; };
-		AFF189CFFE01A0508F5DB418 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B0CC1EB89334CED2AA17A338 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
-		B19DC89501A2EB1FC6B63C48 /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
-		B1AF206D12B17E2E4785EE0B /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
-		B1B55C8F76AC655BCAF3C7B1 /* Tropicalytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Tropicalytics.xcconfig; sourceTree = "<group>"; };
-		B3BF0AF3ED1E29F5D050C387 /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
-		B5DAB6263F944EADCCB1E0B3 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
-		B7166B393D2F1466234EBDE4 /* MARTNSObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MARTNSObject.h; sourceTree = "<group>"; };
-		B77D87CB66AFF6F658080CBA /* Pods-Tropicalytics_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Example-frameworks.sh"; sourceTree = "<group>"; };
-		BBB7D4F10D4F9DF16DEB236B /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
-		BC12960B215034A1DC928A49 /* AFNetworking.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = AFNetworking.modulemap; sourceTree = "<group>"; };
-		BD470CD919162C44CFAC94E0 /* RTProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTProtocol.h; sourceTree = "<group>"; };
-		BDC38B8FA6C7554D45572E9D /* UIImage+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+AFNetworking.h"; path = "UIKit+AFNetworking/UIImage+AFNetworking.h"; sourceTree = "<group>"; };
-		BE0AF38F373EBD721FBE9DED /* TPLFieldGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLFieldGroup.h; sourceTree = "<group>"; };
-		BE8611F39B654CFEA26FCA8D /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
-		BFD4042AC08F1AC1FD8037C5 /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
-		C01E875452718AAE01C726C2 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
-		C0F74B5C2712EC1D97D9E8C3 /* RTIvar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTIvar.m; sourceTree = "<group>"; };
-		C103BBAEC8839CBB13ED6FBB /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
-		C13B712F2C99C95CE0B7E64A /* TPLBatchDetails.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLBatchDetails.h; sourceTree = "<group>"; };
-		C357168F5311B6A832333B65 /* MAObjCRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MAObjCRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C3D1A69BFEADD6D75EDCE592 /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
-		C4B111709923DD89239A38A8 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
-		C56F976358846A2937E887A1 /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
-		C658DEA6F43E389627613A0B /* Tropicalytics.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Tropicalytics.modulemap; sourceTree = "<group>"; };
-		C67DAD95B64BBA021F7B0431 /* Pods-Tropicalytics_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Example.release.xcconfig"; sourceTree = "<group>"; };
-		C8E6726C922AA7D632E2B6D3 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
-		C9844118A441FB6F0DBDF6E5 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
-		CC3B4B88470623347DF8E8E5 /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
-		CC4FA85592547A761132F313 /* TPLDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDatabase.h; sourceTree = "<group>"; };
-		CCD5F6D4A3A753BB795EDCF6 /* TPLUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUtilities.m; sourceTree = "<group>"; };
-		CD665009199C76A30BD8AEF3 /* RTProperty.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTProperty.m; sourceTree = "<group>"; };
-		CE162C857B9E2F73C6B4D7CB /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CF7ED9918505382834E5152B /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
-		CF87848F8610CD8AFE260C80 /* AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-dummy.m"; sourceTree = "<group>"; };
-		D0F28D2F290D6E9BD1686CE3 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
-		D341AA34F8D865255430EDF1 /* Pods-Tropicalytics_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tropicalytics_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		D53B877D0A19E2094582A8AC /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
-		D632081029E3C14EBEFCD84D /* TPLBatchDetails.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLBatchDetails.m; sourceTree = "<group>"; };
-		D70EEE0F84953D326186080D /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
-		DA577FC582254B4F55528543 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
-		DA58047B5C03BB8E71D63823 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
-		DA9B05EF14363EB9A43FF0C1 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
-		DAD9629D4D4BA56BAD0B3F52 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DBA579DD23AC5C564FEAEDE0 /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
-		DBADCF031E3A7B1698939172 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
-		DC2F0662987B6246BA8EE11F /* Pods-Tropicalytics_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		DC76EBF54E48BAACC61331AF /* Pods-Tropicalytics_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		DD469BD56006481A5A5CD7F5 /* TPLAppUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAppUtilities.m; sourceTree = "<group>"; };
-		DF5D304B9F727B7F78A86132 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
-		DFB4D22D98F13570F8593DFB /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E1E43E53703EF200DE9B006A /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
-		E224A2754B4E64A4472FF2BE /* Pods-Tropicalytics_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tropicalytics_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		E2B2BB83C0233A07964E2110 /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
-		E39EB5AE93BDE3228ED3E026 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
-		E4D39C71E02B5C4F10EAE516 /* Tropicalytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Tropicalytics-prefix.pch"; sourceTree = "<group>"; };
-		E5346E864CD48D856BD9F8F8 /* Pods-Tropicalytics_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Tests-resources.sh"; sourceTree = "<group>"; };
-		E53DE92DA6363E41F24CC02A /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
-		E7434050AC818983B34B8E30 /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
-		E752C67574484C1E2C074746 /* TPLRequestManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLRequestManager.h; sourceTree = "<group>"; };
-		E78EA460EFD8BA9241DCCA56 /* Tropicalytics.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tropicalytics.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8A55EB69AAF998F134584F7 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		E9D35DF76902C02C23F51C46 /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
-		ECFF2B0F995DD579E33A6684 /* TPLUniqueIdentifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUniqueIdentifier.h; sourceTree = "<group>"; };
-		ED0390FBAA20A6E648880518 /* Pods-Tropicalytics_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tropicalytics_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		EE3F8083872F8DDB4A326CF3 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
-		EEEB876B4DDABF6126CE34DD /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
-		EFF67D24A44348E86C62A187 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
-		F0A1820E358E26588DA5AB22 /* TPLHeader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLHeader.m; sourceTree = "<group>"; };
-		F14F6FDF0DC1FD567543DF47 /* TPLDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceInfo.m; sourceTree = "<group>"; };
-		F2F7F6CD08ED82222BEEFF64 /* Pods-Tropicalytics_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tropicalytics_Example-dummy.m"; sourceTree = "<group>"; };
-		F4CE2DE2777957FF438C1C6B /* RTUnregisteredClass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTUnregisteredClass.h; sourceTree = "<group>"; };
-		F542FB0AB288ED588CB8EE70 /* TPLUniqueIdentifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUniqueIdentifier.m; sourceTree = "<group>"; };
-		F97B6B05FDC9C58D3FC7FD2F /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
-		FA0BDF66B02A9E6A5A12A1AE /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
-		FB79B4B12177402334AFC706 /* RTMethod.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTMethod.h; sourceTree = "<group>"; };
-		FC226BB352A8418B4DCB839B /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
-		FC4BD3DCC32E6DB3E5E825B0 /* Pods-Tropicalytics_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Example-resources.sh"; sourceTree = "<group>"; };
-		FC6CD67E3FF2827F47E61CE9 /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
-		FCE53783B7A851C7787C2976 /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
-		FF89B40E1C81C216876BFD4F /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
-		FFC91C789B9C2BC425794D66 /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
+		01E16264C985F34BC3E5C6833CCAE1C2 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
+		03DA11B266BF5D359C253F9B37068B8A /* MAObjCRuntime-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MAObjCRuntime-dummy.m"; sourceTree = "<group>"; };
+		044A233B0617BF0B3397B312CD619F02 /* Pods-Tropicalytics_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-Tropicalytics_Example.modulemap"; sourceTree = "<group>"; };
+		051F7B71A3B263FB817CEEA3E2DB351F /* TPLDeviceUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceUtilities.h; sourceTree = "<group>"; };
+		07F895A256F1D4DA24CC9DF911735063 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		093B510C608944D5C2F42932F5BA6070 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
+		093B78EA86E54DC4F3A1B2F947989BD8 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		0A0D6D89A0D6F0ACB4B6E9D469F72CB9 /* Pods-Tropicalytics_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Example-frameworks.sh"; sourceTree = "<group>"; };
+		0C002BF73CF9ED768EC47A919CD0B7B8 /* MARTNSObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MARTNSObject.m; sourceTree = "<group>"; };
+		0C92071F7B076D2F78266367E35DA299 /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
+		0F4E141AC4C5452BDF7C20C57881C711 /* RTUnregisteredClass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTUnregisteredClass.h; sourceTree = "<group>"; };
+		0F8FD7DFC5C51A6A1598E1A5289BE5CA /* AFNetworking.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = AFNetworking.modulemap; sourceTree = "<group>"; };
+		0FC29AF9978E2F882A5D65EB11ABDA9C /* TPLUniqueIdentifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUniqueIdentifier.m; sourceTree = "<group>"; };
+		10FDE9573171D7AC8BBF2C7DD9DEF907 /* TPLAPIClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAPIClient.h; sourceTree = "<group>"; };
+		129291D583AF85C58E9D5336C8110C60 /* TPLRequestManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLRequestManager.h; sourceTree = "<group>"; };
+		1415E6307EB1C9AADFD0EE7FAC3B3076 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1563BDBE9E4EFC68E33D92D0540B58C7 /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
+		161E2A5870AA71357EFB5D3A08330839 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		1758E125466BAD91C4772A1EE949ADDF /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
+		17B8B664D44662993E917EB65B9FA97F /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
+		1858124E2B51C0A1B46A86524BCBC335 /* Specta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Specta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		19EAFD051A6357D7CE67EF4289B99565 /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
+		1A238074057C3C1262FFB1042283E274 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
+		1C374A2B748E32B91C4451F28EC52A41 /* RTIvar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTIvar.h; sourceTree = "<group>"; };
+		1C4583AEB3FEB2574EC241C6DFB1A7E7 /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
+		1DC9C6CA0D0BB185FA3F0CDF859C823F /* TPLHeader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLHeader.m; sourceTree = "<group>"; };
+		1E052C84528CA562DE6AD1FAFB1483E3 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
+		1E7256A26D59AE3CAC26C8D4C479883C /* TPLDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceInfo.m; sourceTree = "<group>"; };
+		1E8797EDA66E9459C5155CC5750A8543 /* AFAutoPurgingImageCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFAutoPurgingImageCache.m; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.m"; sourceTree = "<group>"; };
+		1E8FC18849F34F6ECC95656E05CE29D0 /* TPLUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUtilities.h; sourceTree = "<group>"; };
+		1EEE2C90C5996C1F017C87D64A2A4BD5 /* Pods-Tropicalytics_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Tests-resources.sh"; sourceTree = "<group>"; };
+		1F73FBFCCE22E56C194C05BE1638EB59 /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
+		202FF15792933080E43DF6C3BCDFFAFC /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
+		20FF7AC81EFEBB6E722B793E7EE47F8F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		22C7967C918EC63390360823FB44392D /* Pods-Tropicalytics_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-Tropicalytics_Tests.modulemap"; sourceTree = "<group>"; };
+		2315E4A1E1EA4063E89ABC988B323712 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		237E461836957B621999D3DE5C0FE73C /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
+		24520BAFEECCF3BE67C78D5F333FCFFB /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
+		24978C0D139A516F137BABEAEB5E98A7 /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
+		27272C738519D352C4586A55F5030CEC /* Pods-Tropicalytics_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tropicalytics_Tests-dummy.m"; sourceTree = "<group>"; };
+		2A4D8B739AB877CAEE4AF331A3D61112 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
+		2B83BAEE37ED9AFFCB71B34E701449EB /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
+		2D914C8F02F68FE6FDED7AC68199CC64 /* TPLEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLEvent.h; sourceTree = "<group>"; };
+		2EA05AB0CAD50D3EF236ACBE26B429DD /* TPLConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLConfiguration.m; sourceTree = "<group>"; };
+		2FA47031DF3A795E8CB1AFB6336BDFF1 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
+		307BBB64F62EB5941021C1482CF822B7 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
+		30A5BE22737083E2E2C0BBE3AE47944C /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
+		30F45C340BFE6407CDFCE29A2D7D04DF /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
+		320E4F1C0A54C8EDCDB43A020085444E /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
+		32B76F9E3E7B6D0A432ECFFEAE9E2641 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
+		32BB5BC09F3C0D17A752244A07F34C15 /* RTProperty.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTProperty.m; sourceTree = "<group>"; };
+		32FD0E3AEB5A5FA10271509CC6EA3E91 /* Tropicalytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Tropicalytics-prefix.pch"; sourceTree = "<group>"; };
+		3558F8D47EDEE3265CFC4E49AF263025 /* RTProtocol.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTProtocol.m; sourceTree = "<group>"; };
+		35C99CB0B08DF4FA1AC08D1FE3A2940D /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
+		361EAC416B05CB41CB814FDEE8483B46 /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
+		36D802DFF57F88AC97E275EEC3C7C8C4 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		39A8A444600147CF4FD261431427F59F /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
+		3A97EB4033E95E3C23ABCDA4A9BBB023 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
+		3B539990DF3D9D6F061F705BD1AB97CB /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
+		3C0E3F03C9DBBF2623F15B072F8EE4EB /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
+		3F5D9459A3E51F32781F3DE3C78A7BC3 /* MAObjCRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MAObjCRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FB73A2F8759492AB49BBF7D89AF63B5 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
+		408A7AF14F4CCE770A8EF0288E3B0F4E /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
+		40D00DFC6A32F78AB78B589250AE2967 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
+		40F2ED78511D7AE9C2C461E14BA0FEDE /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
+		41531956376460ADF9969380716F0F4F /* AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-prefix.pch"; sourceTree = "<group>"; };
+		415E5DB48EDB900698A89CAA7404A890 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
+		419F70664EE5599E7899F5564A80790B /* Pods-Tropicalytics_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Example-resources.sh"; sourceTree = "<group>"; };
+		41C3C6F32FCB975511D64FED50808F68 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
+		41EA7EE51CA28000254601EFA38F3774 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		42962234757A0B0C5FB571FFFCE674FB /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
+		43CF91364B7C2BE28963AAD6111E0343 /* AFNetworking-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-umbrella.h"; sourceTree = "<group>"; };
+		43D8F3D174DE77DE4B86232693B09BD0 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
+		4663392B2E73D349D33F16F83710E55A /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
+		4747BD40B00A4C264B2D57BB66B42BD0 /* AFImageDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFImageDownloader.h; path = "UIKit+AFNetworking/AFImageDownloader.h"; sourceTree = "<group>"; };
+		474AF8A86F5D81BFBA1AAC0698EA3A5E /* TPLRequestManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLRequestManager.m; sourceTree = "<group>"; };
+		480CFE354137A41FA155677A165D6F81 /* RTUnregisteredClass.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTUnregisteredClass.m; sourceTree = "<group>"; };
+		491A615DBBEEF3B99DDDE4765484534D /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		494EDEFD85B07BAD114515FD56A8E4BF /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
+		4A5D5E394CB2E1B19ED3577784F31F85 /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
+		4AC49A5BFE891F8DB5C468C22951E853 /* Tropicalytics-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Tropicalytics-umbrella.h"; sourceTree = "<group>"; };
+		4D4C8968A88660F583FC622128E2ED22 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
+		4EF3503053D357443A7E767A8610313E /* Pods-Tropicalytics_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tropicalytics_Example-dummy.m"; sourceTree = "<group>"; };
+		5173BEA05027A0482238C295B668F172 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
+		519AED277A8B6E3B62C824D9845B4BDC /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
+		51CD26F32E89ACC67514C52D073B184F /* MAObjCRuntime-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MAObjCRuntime-prefix.pch"; sourceTree = "<group>"; };
+		522503F048F86DB8B3FC6EF36BEBE6BB /* Expecta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Expecta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		56153DFCF729A0275377DD7B9F669E07 /* TPLHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLHeader.h; sourceTree = "<group>"; };
+		56861037EA61E8AC037C859257B60195 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
+		574875DBC633C280CE29B4C5C92C3B2C /* Pods-Tropicalytics_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Example.release.xcconfig"; sourceTree = "<group>"; };
+		5908EB1D8C9A560497B037792FCA3E12 /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
+		5ACE0D0F4A8B882E5F2B903D657E81AE /* MAObjCRuntime.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = MAObjCRuntime.modulemap; sourceTree = "<group>"; };
+		5CD2665763950A3C776E1B07609F9766 /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
+		5F9920388BF7E9BA120AB890585385BD /* TPLDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDeviceInfo.h; sourceTree = "<group>"; };
+		62B05FDD26E59490F648E62593C27DAB /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
+		635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		65C93B27BBA2E2D35A1F21DB63014370 /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
+		66C43973FE9B62E95CB3E3926B978E49 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
+		66C686FBFB1C276659C7CCC3E6055D1B /* Pods-Tropicalytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		66CFDC007CF7F0BC40864E603BB4A6F2 /* TPLAppUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLAppUtilities.h; sourceTree = "<group>"; };
+		673E0F3028CF6C1C26CF58F579A2096E /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
+		6BCC7698FC5E579C04A61927C14ABB1C /* MARTNSObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MARTNSObject.h; sourceTree = "<group>"; };
+		6C28D7A068FD5494806D45CF62CAAE12 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
+		6C6C1BEBCFF500D96751BACC7B72955B /* Specta-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-umbrella.h"; sourceTree = "<group>"; };
+		6CCD624B009530E994DF7F1F347DBF70 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		6DA0DAA45428E3F33D8D501BC58BB542 /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
+		6E41157E661E63C9548727BBE60EE4A1 /* RTProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTProtocol.h; sourceTree = "<group>"; };
+		6E8E503534AB88BE13BAE3C1E9D9577B /* RTMethod.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTMethod.h; sourceTree = "<group>"; };
+		6ED102F8589E200C5F73DC52E42CFF9F /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
+		6FF36FE6578030BCCA059AFF12F84F33 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
+		70EFBB03414DEA461DE88C7569E67966 /* TPLAPIClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAPIClient.m; sourceTree = "<group>"; };
+		7161B7AF2FB9133556E8B9235C639372 /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
+		72030FC356763407445C4C16E26E804B /* Tropicalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Tropicalytics.m; sourceTree = "<group>"; };
+		729EE2B07BC4CE1C4963B64E42594C3B /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
+		72D165B527C6B04FA62635FA695DF34C /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
+		736825C14AB0DC5059B2304F01FCE599 /* Tropicalytics.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tropicalytics.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		74134635D078692BF3F5DEFB39EC00DD /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
+		7426C29FF85B6E36B03DACAE7EEC492A /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
+		75935C78F1DA4FD81E06F4E3928E514B /* RTIvar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTIvar.m; sourceTree = "<group>"; };
+		75F1ED3E9BFB58DC6A7AA8AD520C3182 /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
+		760BE70119445BF8B9C8C842A50BEFB6 /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		7A0E1A7B30BD4B8B0D5BCC0423FBA75B /* Pods-Tropicalytics_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tropicalytics_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		7AD57EDC7684E72652BEFB94BCBBB0F3 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
+		7DD46F4E92C064ED5D0ADBA027F0BCB9 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
+		7EFDAEE9BC9F9FD933F7E554804748B0 /* Expecta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Expecta.modulemap; sourceTree = "<group>"; };
+		7FEB382CED9092B586EF9D2FCC6CE2D6 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8082CF3EC0D52A8F6187E6DEA1921154 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
+		81A4C6359BEA818EE50CE3AFF5CBF3F8 /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
+		824A89C3ED13835DC40D6AF7EC2093E8 /* MAObjCRuntime-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MAObjCRuntime-umbrella.h"; sourceTree = "<group>"; };
+		82B8E00C315300EDBFDE07086D5F8812 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
+		82DAA1EFED847C2CDE1357092F1FA251 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
+		84CF0E427569F2E1E2677C6C75D1A30C /* Pods-Tropicalytics_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		860E8360D18B7E55222AD02C6FA6866C /* MAObjCRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MAObjCRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		861A1063371F50AE8F228277743A826F /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
+		8630638A604C4758596FE7FAE50837E8 /* Pods_Tropicalytics_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tropicalytics_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		867D9AF4FF470DA68D363C120DB72FA6 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
+		86BBDF325054136E536E454554BC48BB /* Pods-Tropicalytics_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tropicalytics_Example-umbrella.h"; sourceTree = "<group>"; };
+		87662EBF42E6FAD0E92226F8163E2E5B /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
+		885C7DBB171E6DEEAA643351A6772262 /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
+		890B11D7D6F4BFBEECD999A94E27A786 /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
+		894C61FD5422603B33778B9F4DCC2BFE /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
+		8BC27F5BB3011BCD928586C46E44B88A /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
+		8DE48683247B727F0F0219645EE1F9F5 /* Pods-Tropicalytics_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tropicalytics_Tests-umbrella.h"; sourceTree = "<group>"; };
+		91058F81BD0433273EC4438A9174CED0 /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
+		92E102577061A6A34DE8A16029664F04 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
+		964C5C701CA5BE5F3E809764EED57730 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
+		98FFF4E23EBAA35E9CD3C73F34C574A1 /* Pods-Tropicalytics_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tropicalytics_Tests-frameworks.sh"; sourceTree = "<group>"; };
+		9924A1DA480804CCE203BFF7F4938D30 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
+		99454B3D73AD2499FD2124516E9FCA9B /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
+		9A33BF6D48242005A5EE8B489B416344 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		9AAE48B66D04BFE93C713663A4CD3643 /* Expecta-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-umbrella.h"; sourceTree = "<group>"; };
+		9CBED299A0FBDE512F7165485EF5EE88 /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		9CF3B31D6EB40D222FA08270D03DA2BE /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
+		9D12B83609131AA8AB7378C863397150 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9DF866059F140F5989F0BD8B787F534B /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
+		9E7EC431E31C96FE95D4C77B14BA468E /* AFNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AFNetworking.xcconfig; sourceTree = "<group>"; };
+		9F4C09D5ABB3852A4B6BB308211FB888 /* UIImage+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+AFNetworking.h"; path = "UIKit+AFNetworking/UIImage+AFNetworking.h"; sourceTree = "<group>"; };
+		9F782B9DEA7183C5D0ACF08414A92205 /* TPLFieldGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLFieldGroup.h; sourceTree = "<group>"; };
+		A2698707ECE89224BC884265E7F119A9 /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
+		A2AD7EB4E8714E288666876EFBC00C62 /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
+		A4B4272766A9E7112FE2C1938F60E1E4 /* TPLFieldGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLFieldGroup.m; sourceTree = "<group>"; };
+		A4E58C232854B6285AEF18F572A5C7E2 /* Pods_Tropicalytics_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tropicalytics_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A51AFA314793A1C7F3DF89A27FD7CAF6 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
+		A5F065665741190D3660CF916B33C4F0 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
+		A8C8BD49A285284CD8ACC1CC30EA3D08 /* contents */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; path = contents; sourceTree = "<group>"; };
+		A9F1435AF8F9F903D34031C41619D1D8 /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
+		AA07502408A9CA91389B8D50F3018B7A /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
+		AB7AE0EE9DE6B46FF27123DD36EE7656 /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
+		AC3EC58E73C4FD397442C88C140EA6B9 /* RTProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RTProperty.h; sourceTree = "<group>"; };
+		AECB9DB0D789BA63A4E2DB48E9F911FD /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
+		AF517D87C43C257FAFED6A2201585887 /* MAObjCRuntime.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MAObjCRuntime.xcconfig; sourceTree = "<group>"; };
+		AFD1A4872CB7470298D32DC943DB40CC /* TPLConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLConstants.h; sourceTree = "<group>"; };
+		B0423736FFA88FE8EA2A41E79DC2E601 /* Pods-Tropicalytics_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tropicalytics_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		B0FC275883179BBF9A4E8547B8C41319 /* Pods-Tropicalytics_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tropicalytics_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		B240313F1B213A37D8975DAC2B614D78 /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
+		B24FD7D9D711C287927C6E7642219553 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		B2E2AA3BD43F0531C251D67BB29CD3D9 /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
+		B905271BF44822792EA48DF27A4B6416 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
+		B91DEF511AAE5AB047AC6233D7FA1AC5 /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
+		B9398525D563222C3D2BEAF9AF2F8A1B /* Specta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Specta.modulemap; sourceTree = "<group>"; };
+		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BAE57C33490B0B1AF6088B01E11F886A /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
+		BC0CB761C4BB4E20B22FF6E4DC06F449 /* TPLUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLUtilities.m; sourceTree = "<group>"; };
+		BC298EF491113D68B9F125ED633F3073 /* RTMethod.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RTMethod.m; sourceTree = "<group>"; };
+		BD0820FED0B34F7C4C4F85F5A9093331 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
+		BD208BA9B66F9E1B71802D78A04F7A54 /* TPLConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLConfiguration.h; sourceTree = "<group>"; };
+		BD8DA0F7C54949412A8BA81A6DCDDF99 /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
+		BE21A7FBF8302A2512C06A938AF92D38 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BECD7A1B03527A00FDC7416D15C3DFAD /* Tropicalytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Tropicalytics-dummy.m"; sourceTree = "<group>"; };
+		BF8A5D5FD78116FFAE774939DB19CE7D /* Tropicalytics.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Tropicalytics.modulemap; sourceTree = "<group>"; };
+		C0E2D7FB534E463EF3F0180767F9BF2E /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
+		C1D32078D598BC895DA140F206554C45 /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
+		C2251CFFE0AEB3F7789BCC2FA0429033 /* Tropicalytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Tropicalytics.xcconfig; sourceTree = "<group>"; };
+		C2D075CB92702C3A3ED3494231C01B30 /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
+		C4273C160F01D8F128DEF6AD5469CF7E /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
+		C4DF160A02BC4D99EB5BF20C1B9E1C37 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
+		C67017CE1BD11A06E84EA27AB3D291F3 /* TPLEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLEvent.m; sourceTree = "<group>"; };
+		C6A45D52E036332B840FDDEE65FD2187 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
+		C7AEFEFED9284ADC51610E077D769673 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
+		C83E0E9D4E7A0B0813E910959CD27676 /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
+		C8D525080DB3346BD6FCE77CE9789155 /* TPLAppUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLAppUtilities.m; sourceTree = "<group>"; };
+		C9C5C1888711FD6E2DF19960C63234BF /* TPLDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDatabase.m; sourceTree = "<group>"; };
+		CAAF695DDD22B3FB18EFDFE29859B1F6 /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
+		CB786BCEFF819325F842A6F68A078C71 /* Tropicalytics.xcdatamodel */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcdatamodel; path = Tropicalytics.xcdatamodel; sourceTree = "<group>"; };
+		CD5EDF0B03235EAC81199D4B695802CD /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
+		CE56C189D1436871EA1BEF1E230581CB /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
+		CEE427098396C593D40404C4677072AB /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D00B1214FB2249B17D63477FC575F1BE /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
+		D3501FFC901C55619F1B7B16AFC662AC /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
+		D3FD828DDF23CB2D5927E7ADAD3B0FF8 /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
+		D4AA48A433ECB2BBF26BC7A11505F014 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
+		D4C1115012E054B7D6FCC123E9978886 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		D52DB94783212DD28C11307030370DFE /* TPLBatchDetails.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLBatchDetails.h; sourceTree = "<group>"; };
+		D5C62B64A0A67B6535BE66A210B01F3D /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
+		D8E869FEDAEF2E552F5461B57AFD21B1 /* TPLDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLDatabase.h; sourceTree = "<group>"; };
+		D9D475117EC54B7ECA993740AFB82D17 /* Tropicalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tropicalytics.h; sourceTree = "<group>"; };
+		DCA8D189A7F64A2E1EFEB1D492E5C9B0 /* Pods-Tropicalytics_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tropicalytics_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		DDCE0EBDBFD893D8A128BD9507A95CC6 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
+		DE3064393EAFA98ADCBB0F51F9928D61 /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
+		DED59F076B9E088A6E5F98EB8C00BC86 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
+		E0311F0CA5EBFD85E51FC577126C74ED /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
+		E46DD46C9B83578FA4AB3E4E99AA6060 /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
+		E5F1387418F145763DA282A84C8085F8 /* Pods-Tropicalytics_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tropicalytics_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		E67D9EF3FAE85219A5649B6A3F23E794 /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
+		E6C6D7BC17B35FF9C88A48F86720F247 /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
+		E8883EB79D821E17A15157143B3ABAFF /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E89085B4B3B8B3F1F6AFABC95047B569 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		EBC8529A48A40CE22A3849E786B4DC2E /* TPLDeviceUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLDeviceUtilities.m; sourceTree = "<group>"; };
+		ED5A9AB9707480312760E8FCD2DB7786 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		EE3FAF391B2C5938158F8CCC8BA698BD /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		EEC75ACA62ADAEFB0A5D1F782A08BFC4 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
+		EEE020DA7F324BBDC31D5B9A482D6582 /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
+		EF466BAED148A632F0D86B94710EE5C7 /* AFImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFImageDownloader.m; path = "UIKit+AFNetworking/AFImageDownloader.m"; sourceTree = "<group>"; };
+		F3FB804742793E24AB40997E3EBB8ED9 /* TPLUniqueIdentifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TPLUniqueIdentifier.h; sourceTree = "<group>"; };
+		F66A3AD5F3C42945C074B85D70D879CB /* Tropicalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tropicalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F709232E06B813FEE808885A22496F5A /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
+		F7C25F11412715116910791D675543C9 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
+		F9EB460416B1C4938820DC263FB509EC /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
+		FC238BFEC74E3A52A65122EF10679100 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		FCD3A2AA836ECFC16788AD4653B3C797 /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
+		FCE5230B87A0E4745AF4A6106015F45A /* TPLBatchDetails.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TPLBatchDetails.m; sourceTree = "<group>"; };
+		FDD6FD00CC0E9A86AD839FFB2434F08D /* AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-dummy.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		4476D762CE860E5BDBC531D4 /* Frameworks */ = {
+		3576A6E9DFD28A6934DA791A048FAC76 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3632FAED8FD7536DCD0B1E67 /* Foundation.framework in Frameworks */,
+				884E62C59DCFD8F1FBF4B3F3324BE069 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		57CECD599106EA0821E86D71 /* Frameworks */ = {
+		40031F77D6C4EDDA67D483EB7EF0293E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF63081DBD63FF0B152A4CAE /* Foundation.framework in Frameworks */,
-				E52116BD73445D097B684DA8 /* XCTest.framework in Frameworks */,
+				FACA3A4407CD9E34C76640F7D1601003 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5B43E9AC9AFDD307D4D804AD /* Frameworks */ = {
+		4B14518ED39BDEC8F751269D29E93EF9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC730614A2CBBF9F5A07B39021AD0407 /* Foundation.framework in Frameworks */,
+				1B4583D6E68B3C76C754D57835707F89 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		60906E09C1AE35575754979D /* Frameworks */ = {
+		95182BB079148AFF271DF4753F745FB8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				647CC9E5C65F7776DBC4A10B /* Foundation.framework in Frameworks */,
+				C2CF0EB220F8F42DF5398D53B0AE5A0C /* AFNetworking.framework in Frameworks */,
+				3A36886057E5A931014ACC66023B8431 /* CoreData.framework in Frameworks */,
+				2E7F13CBDDBD5D1E32FD42D6A99F6EFD /* Foundation.framework in Frameworks */,
+				CE7416A504B2D1121091BEED0F07EA75 /* MAObjCRuntime.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7602D1E66F24D14A1AB4EAFE /* Frameworks */ = {
+		C151364F15F39F7CC60CBF9A3AB49B44 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2DFA7C7D4BAB3365FD626164 /* CoreGraphics.framework in Frameworks */,
-				B5D8BAA534B2632923F4ADCD /* Foundation.framework in Frameworks */,
-				181D4EFC9EC584AFEF544EB2 /* MobileCoreServices.framework in Frameworks */,
-				B5FECFDC215717DA90D42AB8 /* Security.framework in Frameworks */,
-				721D0897FD809CCAD8CEB8DF /* SystemConfiguration.framework in Frameworks */,
+				7E6A4EFA32969CDB9F9C57903152BA54 /* CoreGraphics.framework in Frameworks */,
+				7F17EA5E2787B6F2BBB359854B42A0E3 /* Foundation.framework in Frameworks */,
+				D04B84B53456B9CD8A7236126075571B /* MobileCoreServices.framework in Frameworks */,
+				C01AC3BAD9037A8A1E45FD17336C15F3 /* Security.framework in Frameworks */,
+				3A10EF6ABF51D1D00B06AC5EF3A8C28C /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D50F20778358933676A493C9 /* Frameworks */ = {
+		C53809CE4D7D1E47C6A852D8F1FAEE1F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6884F6D75A194677DF9F106E /* Foundation.framework in Frameworks */,
+				23500E6D25DA1901837F20BB447C21A8 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DD4F030FBA0C3B0A8F7E6C8D /* Frameworks */ = {
+		E6B836B352B13C63D3C0FA0E500C98A4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C11EA415E1461999E2D6081C /* AFNetworking.framework in Frameworks */,
-				51FCCE5C72734B3606C9708F /* CoreData.framework in Frameworks */,
-				5A04AF57E4A6ACEEF10EA47F /* Foundation.framework in Frameworks */,
-				15F11CCB60D2054B40E30E50 /* MAObjCRuntime.framework in Frameworks */,
+				160FDA46EE919AAF97E0E4EC04C9E232 /* Foundation.framework in Frameworks */,
+				7A211860F672261C1522DCDF1FFC9ED0 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FE4C4B9AD57AA88725EAFF5E /* Frameworks */ = {
+		EBEDA26C460270751B48587DDAA00ECB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				41E7614A4C4F719D707B24B8 /* Foundation.framework in Frameworks */,
-				F831DC40F99709F044C0AC27 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		00F2A99B5FB30D71AE0D70BB /* MAObjCRuntime */ = {
+		02E354557C7B9D0D9BABA163CAB4E367 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				B7166B393D2F1466234EBDE4 /* MARTNSObject.h */,
-				2A612BBEBE21D482C527BF88 /* MARTNSObject.m */,
-				4F90B73F8BB62B021E5A7C65 /* RTIvar.h */,
-				C0F74B5C2712EC1D97D9E8C3 /* RTIvar.m */,
-				FB79B4B12177402334AFC706 /* RTMethod.h */,
-				A2CDFE712A611A8561EF6FF1 /* RTMethod.m */,
-				7E7BED9A79E623C377FEAE0B /* RTProperty.h */,
-				CD665009199C76A30BD8AEF3 /* RTProperty.m */,
-				BD470CD919162C44CFAC94E0 /* RTProtocol.h */,
-				1F178181CF9AFC7CFC7D7322 /* RTProtocol.m */,
-				F4CE2DE2777957FF438C1C6B /* RTUnregisteredClass.h */,
-				177E1FC3A550E5B8A4ADFDC1 /* RTUnregisteredClass.m */,
-				D7C478DEBDBD601B06C4BB90 /* Support Files */,
-			);
-			path = MAObjCRuntime;
-			sourceTree = "<group>";
-		};
-		041F8E7AE75A024D87E735DD /* UIKit */ = {
-			isa = PBXGroup;
-			children = (
-				49A897FC3A2F4F68D00DCCCB /* AFAutoPurgingImageCache.h */,
-				378474427426D5E2AAD24457 /* AFAutoPurgingImageCache.m */,
-				78EBF49E29858794DFA1B00B /* AFImageDownloader.h */,
-				1AC8BFB195F0887A62085703 /* AFImageDownloader.m */,
-				6B6E8F52C410627D6CCE0780 /* AFNetworkActivityIndicatorManager.h */,
-				C4B111709923DD89239A38A8 /* AFNetworkActivityIndicatorManager.m */,
-				4D5D53F2DAF996E2DBC7B87E /* UIActivityIndicatorView+AFNetworking.h */,
-				7D2B678351E0D73A7C559902 /* UIActivityIndicatorView+AFNetworking.m */,
-				2939B9E1537A58CEC9F3282D /* UIButton+AFNetworking.h */,
-				DBA579DD23AC5C564FEAEDE0 /* UIButton+AFNetworking.m */,
-				BDC38B8FA6C7554D45572E9D /* UIImage+AFNetworking.h */,
-				02A4D8CADACB136E4A9EB35D /* UIImageView+AFNetworking.h */,
-				805BFACA7D7BF937F045481A /* UIImageView+AFNetworking.m */,
-				1E7BD51892DA4CDF048B6578 /* UIKit+AFNetworking.h */,
-				6268E5E47C1501E54CDDAF3A /* UIProgressView+AFNetworking.h */,
-				1953BB817695539E365D4A2F /* UIProgressView+AFNetworking.m */,
-				67602D34B5FDFC1E00A1BDA2 /* UIRefreshControl+AFNetworking.h */,
-				464D3CD22B42A6285C4AD91C /* UIRefreshControl+AFNetworking.m */,
-				DBADCF031E3A7B1698939172 /* UIWebView+AFNetworking.h */,
-				369B61EF3CB48FB673F54588 /* UIWebView+AFNetworking.m */,
+				19EAFD051A6357D7CE67EF4289B99565 /* AFAutoPurgingImageCache.h */,
+				1E8797EDA66E9459C5155CC5750A8543 /* AFAutoPurgingImageCache.m */,
+				4747BD40B00A4C264B2D57BB66B42BD0 /* AFImageDownloader.h */,
+				EF466BAED148A632F0D86B94710EE5C7 /* AFImageDownloader.m */,
+				EE3FAF391B2C5938158F8CCC8BA698BD /* AFNetworkActivityIndicatorManager.h */,
+				415E5DB48EDB900698A89CAA7404A890 /* AFNetworkActivityIndicatorManager.m */,
+				9CBED299A0FBDE512F7165485EF5EE88 /* UIActivityIndicatorView+AFNetworking.h */,
+				890B11D7D6F4BFBEECD999A94E27A786 /* UIActivityIndicatorView+AFNetworking.m */,
+				760BE70119445BF8B9C8C842A50BEFB6 /* UIButton+AFNetworking.h */,
+				1758E125466BAD91C4772A1EE949ADDF /* UIButton+AFNetworking.m */,
+				9F4C09D5ABB3852A4B6BB308211FB888 /* UIImage+AFNetworking.h */,
+				07F895A256F1D4DA24CC9DF911735063 /* UIImageView+AFNetworking.h */,
+				E89085B4B3B8B3F1F6AFABC95047B569 /* UIImageView+AFNetworking.m */,
+				5173BEA05027A0482238C295B668F172 /* UIKit+AFNetworking.h */,
+				17B8B664D44662993E917EB65B9FA97F /* UIProgressView+AFNetworking.h */,
+				2FA47031DF3A795E8CB1AFB6336BDFF1 /* UIProgressView+AFNetworking.m */,
+				BD0820FED0B34F7C4C4F85F5A9093331 /* UIRefreshControl+AFNetworking.h */,
+				1E052C84528CA562DE6AD1FAFB1483E3 /* UIRefreshControl+AFNetworking.m */,
+				D4C1115012E054B7D6FCC123E9978886 /* UIWebView+AFNetworking.h */,
+				6CCD624B009530E994DF7F1F347DBF70 /* UIWebView+AFNetworking.m */,
 			);
 			name = UIKit;
 			sourceTree = "<group>";
 		};
-		0636FFA4B1B3FAF4437A27B1 /* Tropicalytics.xcdatamodel */ = {
+		0576066EFB738D9918051A5CBF34A045 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				44EB3EFF693546C0A537E5E3 /* contents */,
+				AC38E9A2EAC639FF8F4021DA6969D24F /* Classes */,
 			);
-			path = Tropicalytics.xcdatamodel;
+			path = Pod;
 			sourceTree = "<group>";
 		};
-		0D52594FA2683364AA5D5092 /* Database */ = {
+		1B31EDB57B03D10E1F55BE56C8E55A94 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				CC4FA85592547A761132F313 /* TPLDatabase.h */,
-				8F6ACD9C60B05C27481AD288 /* TPLDatabase.m */,
+				C148A9E34F5999A108C3A5765A0FB2BF /* Pods-Tropicalytics_Example */,
+				85F6D6690EA884E8641ADB15D07827E7 /* Pods-Tropicalytics_Tests */,
 			);
-			path = Database;
+			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		14D17A19A74CC11C8062E891 /* Utilities */ = {
+		3096E8A9BF15B8AD1F2C70946F70CACB /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				25087426B87159887C8DB805 /* TPLAppUtilities.h */,
-				DD469BD56006481A5A5CD7F5 /* TPLAppUtilities.m */,
-				2B9D79E81444B10EE26E6858 /* TPLDeviceUtilities.h */,
-				26E77000308C33F4EEF3B78B /* TPLDeviceUtilities.m */,
-				33EDFB63C4724400C15D80BE /* TPLUtilities.h */,
-				CCD5F6D4A3A753BB795EDCF6 /* TPLUtilities.m */,
+				66CFDC007CF7F0BC40864E603BB4A6F2 /* TPLAppUtilities.h */,
+				C8D525080DB3346BD6FCE77CE9789155 /* TPLAppUtilities.m */,
+				051F7B71A3B263FB817CEEA3E2DB351F /* TPLDeviceUtilities.h */,
+				EBC8529A48A40CE22A3849E786B4DC2E /* TPLDeviceUtilities.m */,
+				1E8FC18849F34F6ECC95656E05CE29D0 /* TPLUtilities.h */,
+				BC0CB761C4BB4E20B22FF6E4DC06F449 /* TPLUtilities.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
 		};
-		32055ACE182B3B98DC674EB9 /* Tropicalytics */ = {
+		3142513D12EDAA0EC41878878677D97B /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				56AA791385A7F81E81399BB6 /* Pod */,
-				9C6F03F931D27E5BC0D6F3C7 /* Resources */,
-				7C1CAB2EB5571C81C912FAE7 /* Support Files */,
+				6BC038CE2E4121A9F1DF50B55B8C0307 /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		3C305BB271A82340690BE7BF474FCE73 /* Tropicalytics */ = {
+			isa = PBXGroup;
+			children = (
+				3142513D12EDAA0EC41878878677D97B /* Pod */,
+				B7B1290F18011342C080DB0770CAE702 /* Resources */,
+				B502CD19B79E529A2E5D393D2195D846 /* Support Files */,
 			);
 			name = Tropicalytics;
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		37402DB123D422FAE9CEFCAF /* Products */ = {
+		3DBAE87581DC41D1B2286B47D8B52781 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				381BD6E0206D8212754AD170 /* AFNetworking.framework */,
-				16C68FCC6AFEDA88107C10FD /* Expecta.framework */,
-				2D1C1FA95148C00B5C0EE315 /* MAObjCRuntime.framework */,
-				6BDFE707A23940C4E60396BF /* Pods_Tropicalytics_Example.framework */,
-				402B31CD85EDCCFCE6EE6487 /* Pods_Tropicalytics_Tests.framework */,
-				149FB071D5A9B00862C1C10A /* Specta.framework */,
-				E78EA460EFD8BA9241DCCA56 /* Tropicalytics.bundle */,
-				96199037BF78A999576FA839 /* Tropicalytics.framework */,
+				BD208BA9B66F9E1B71802D78A04F7A54 /* TPLConfiguration.h */,
+				2EA05AB0CAD50D3EF236ACBE26B429DD /* TPLConfiguration.m */,
 			);
-			name = Products;
+			path = Config;
 			sourceTree = "<group>";
 		};
-		3B4D4692CC494F741FDCEBCA /* Development Pods */ = {
+		44B8A9DD36DDE9C4AA7E8DE4AB743AE9 /* APIClient */ = {
 			isa = PBXGroup;
 			children = (
-				32055ACE182B3B98DC674EB9 /* Tropicalytics */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		56AA791385A7F81E81399BB6 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				D88CBCA78A8E9126FF156EB0 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		5E3C194FD392B9851E233304 /* APIClient */ = {
-			isa = PBXGroup;
-			children = (
-				76F494A81E03B23A95B192C5 /* TPLAPIClient.h */,
-				896D21F7E54C90AA28B3C9C4 /* TPLAPIClient.m */,
+				10FDE9573171D7AC8BBF2C7DD9DEF907 /* TPLAPIClient.h */,
+				70EFBB03414DEA461DE88C7569E67966 /* TPLAPIClient.m */,
 			);
 			path = APIClient;
 			sourceTree = "<group>";
 		};
-		6BF5D780D6FC7E0346AB6685 = {
+		4ADBBB723AA07BFD2A74C0BFFDABDF27 /* Specta */ = {
 			isa = PBXGroup;
 			children = (
-				2C8EF197A0779AFB16F0656D /* Podfile */,
-				3B4D4692CC494F741FDCEBCA /* Development Pods */,
-				E51289AB853D94D1637D588F /* Frameworks */,
-				E43FD76E9649B15302BEC821 /* Pods */,
-				37402DB123D422FAE9CEFCAF /* Products */,
-				9DCADC85CECDEBCF30A25724 /* Targets Support Files */,
+				82B8E00C315300EDBFDE07086D5F8812 /* Specta.h */,
+				AECB9DB0D789BA63A4E2DB48E9F911FD /* SpectaDSL.h */,
+				B240313F1B213A37D8975DAC2B614D78 /* SpectaDSL.m */,
+				6ED102F8589E200C5F73DC52E42CFF9F /* SpectaTypes.h */,
+				8082CF3EC0D52A8F6187E6DEA1921154 /* SpectaUtility.h */,
+				A2AD7EB4E8714E288666876EFBC00C62 /* SpectaUtility.m */,
+				D00B1214FB2249B17D63477FC575F1BE /* SPTCallSite.h */,
+				7AD57EDC7684E72652BEFB94BCBBB0F3 /* SPTCallSite.m */,
+				894C61FD5422603B33778B9F4DCC2BFE /* SPTCompiledExample.h */,
+				AA07502408A9CA91389B8D50F3018B7A /* SPTCompiledExample.m */,
+				DDCE0EBDBFD893D8A128BD9507A95CC6 /* SPTExample.h */,
+				519AED277A8B6E3B62C824D9845B4BDC /* SPTExample.m */,
+				FCD3A2AA836ECFC16788AD4653B3C797 /* SPTExampleGroup.h */,
+				40F2ED78511D7AE9C2C461E14BA0FEDE /* SPTExampleGroup.m */,
+				161E2A5870AA71357EFB5D3A08330839 /* SPTExcludeGlobalBeforeAfterEach.h */,
+				ED5A9AB9707480312760E8FCD2DB7786 /* SPTGlobalBeforeAfterEach.h */,
+				56861037EA61E8AC037C859257B60195 /* SPTSharedExampleGroups.h */,
+				C6A45D52E036332B840FDDEE65FD2187 /* SPTSharedExampleGroups.m */,
+				7161B7AF2FB9133556E8B9235C639372 /* SPTSpec.h */,
+				6C28D7A068FD5494806D45CF62CAAE12 /* SPTSpec.m */,
+				75F1ED3E9BFB58DC6A7AA8AD520C3182 /* SPTTestSuite.h */,
+				30A5BE22737083E2E2C0BBE3AE47944C /* SPTTestSuite.m */,
+				3B539990DF3D9D6F061F705BD1AB97CB /* XCTest+Private.h */,
+				CE56C189D1436871EA1BEF1E230581CB /* XCTestCase+Specta.h */,
+				729EE2B07BC4CE1C4963B64E42594C3B /* XCTestCase+Specta.m */,
+				B56D21217C6463199D9F7C479AE03D19 /* Support Files */,
+			);
+			path = Specta;
+			sourceTree = "<group>";
+		};
+		4EF2BE21F5418278F7ACF4FCEEE50C24 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				3C305BB271A82340690BE7BF474FCE73 /* Tropicalytics */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		5DD6B10CDE4284EE8A0EFA8154CFDBFD /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				2B83BAEE37ED9AFFCB71B34E701449EB /* AFSecurityPolicy.h */,
+				C7AEFEFED9284ADC51610E077D769673 /* AFSecurityPolicy.m */,
+			);
+			name = Security;
+			sourceTree = "<group>";
+		};
+		638A50B2630ADE6081EFDE86E3C53FC1 /* Expecta */ = {
+			isa = PBXGroup;
+			children = (
+				C1D32078D598BC895DA140F206554C45 /* EXPBlockDefinedMatcher.h */,
+				74134635D078692BF3F5DEFB39EC00DD /* EXPBlockDefinedMatcher.m */,
+				A51AFA314793A1C7F3DF89A27FD7CAF6 /* EXPDefines.h */,
+				CAAF695DDD22B3FB18EFDFE29859B1F6 /* EXPDoubleTuple.h */,
+				3FB73A2F8759492AB49BBF7D89AF63B5 /* EXPDoubleTuple.m */,
+				6DA0DAA45428E3F33D8D501BC58BB542 /* Expecta.h */,
+				F709232E06B813FEE808885A22496F5A /* ExpectaObject.h */,
+				65C93B27BBA2E2D35A1F21DB63014370 /* ExpectaObject.m */,
+				81A4C6359BEA818EE50CE3AFF5CBF3F8 /* ExpectaSupport.h */,
+				66C43973FE9B62E95CB3E3926B978E49 /* ExpectaSupport.m */,
+				82DAA1EFED847C2CDE1357092F1FA251 /* EXPExpect.h */,
+				D3FD828DDF23CB2D5927E7ADAD3B0FF8 /* EXPExpect.m */,
+				9DF866059F140F5989F0BD8B787F534B /* EXPFloatTuple.h */,
+				964C5C701CA5BE5F3E809764EED57730 /* EXPFloatTuple.m */,
+				237E461836957B621999D3DE5C0FE73C /* EXPMatcher.h */,
+				4663392B2E73D349D33F16F83710E55A /* EXPMatcherHelpers.h */,
+				CD5EDF0B03235EAC81199D4B695802CD /* EXPMatcherHelpers.m */,
+				2A4D8B739AB877CAEE4AF331A3D61112 /* EXPMatchers.h */,
+				8BC27F5BB3011BCD928586C46E44B88A /* EXPMatchers+beCloseTo.h */,
+				F7C25F11412715116910791D675543C9 /* EXPMatchers+beCloseTo.m */,
+				494EDEFD85B07BAD114515FD56A8E4BF /* EXPMatchers+beFalsy.h */,
+				87662EBF42E6FAD0E92226F8163E2E5B /* EXPMatchers+beFalsy.m */,
+				A5F065665741190D3660CF916B33C4F0 /* EXPMatchers+beginWith.h */,
+				6FF36FE6578030BCCA059AFF12F84F33 /* EXPMatchers+beginWith.m */,
+				1F73FBFCCE22E56C194C05BE1638EB59 /* EXPMatchers+beGreaterThan.h */,
+				D4AA48A433ECB2BBF26BC7A11505F014 /* EXPMatchers+beGreaterThan.m */,
+				EEE020DA7F324BBDC31D5B9A482D6582 /* EXPMatchers+beGreaterThanOrEqualTo.h */,
+				4D4C8968A88660F583FC622128E2ED22 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
+				24520BAFEECCF3BE67C78D5F333FCFFB /* EXPMatchers+beIdenticalTo.h */,
+				307BBB64F62EB5941021C1482CF822B7 /* EXPMatchers+beIdenticalTo.m */,
+				32B76F9E3E7B6D0A432ECFFEAE9E2641 /* EXPMatchers+beInstanceOf.h */,
+				35C99CB0B08DF4FA1AC08D1FE3A2940D /* EXPMatchers+beInstanceOf.m */,
+				91058F81BD0433273EC4438A9174CED0 /* EXPMatchers+beInTheRangeOf.h */,
+				408A7AF14F4CCE770A8EF0288E3B0F4E /* EXPMatchers+beInTheRangeOf.m */,
+				B2E2AA3BD43F0531C251D67BB29CD3D9 /* EXPMatchers+beKindOf.h */,
+				F9EB460416B1C4938820DC263FB509EC /* EXPMatchers+beKindOf.m */,
+				40D00DFC6A32F78AB78B589250AE2967 /* EXPMatchers+beLessThan.h */,
+				B91DEF511AAE5AB047AC6233D7FA1AC5 /* EXPMatchers+beLessThan.m */,
+				42962234757A0B0C5FB571FFFCE674FB /* EXPMatchers+beLessThanOrEqualTo.h */,
+				361EAC416B05CB41CB814FDEE8483B46 /* EXPMatchers+beLessThanOrEqualTo.m */,
+				C2D075CB92702C3A3ED3494231C01B30 /* EXPMatchers+beNil.h */,
+				C0E2D7FB534E463EF3F0180767F9BF2E /* EXPMatchers+beNil.m */,
+				DED59F076B9E088A6E5F98EB8C00BC86 /* EXPMatchers+beSubclassOf.h */,
+				E67D9EF3FAE85219A5649B6A3F23E794 /* EXPMatchers+beSubclassOf.m */,
+				861A1063371F50AE8F228277743A826F /* EXPMatchers+beSupersetOf.h */,
+				5CD2665763950A3C776E1B07609F9766 /* EXPMatchers+beSupersetOf.m */,
+				E6C6D7BC17B35FF9C88A48F86720F247 /* EXPMatchers+beTruthy.h */,
+				673E0F3028CF6C1C26CF58F579A2096E /* EXPMatchers+beTruthy.m */,
+				7426C29FF85B6E36B03DACAE7EEC492A /* EXPMatchers+conformTo.h */,
+				7DD46F4E92C064ED5D0ADBA027F0BCB9 /* EXPMatchers+conformTo.m */,
+				B905271BF44822792EA48DF27A4B6416 /* EXPMatchers+contain.h */,
+				30F45C340BFE6407CDFCE29A2D7D04DF /* EXPMatchers+contain.m */,
+				885C7DBB171E6DEEAA643351A6772262 /* EXPMatchers+endWith.h */,
+				9924A1DA480804CCE203BFF7F4938D30 /* EXPMatchers+endWith.m */,
+				EEC75ACA62ADAEFB0A5D1F782A08BFC4 /* EXPMatchers+equal.h */,
+				4A5D5E394CB2E1B19ED3577784F31F85 /* EXPMatchers+equal.m */,
+				9CF3B31D6EB40D222FA08270D03DA2BE /* EXPMatchers+haveCountOf.h */,
+				24978C0D139A516F137BABEAEB5E98A7 /* EXPMatchers+haveCountOf.m */,
+				E0311F0CA5EBFD85E51FC577126C74ED /* EXPMatchers+match.h */,
+				1563BDBE9E4EFC68E33D92D0540B58C7 /* EXPMatchers+match.m */,
+				01E16264C985F34BC3E5C6833CCAE1C2 /* EXPMatchers+postNotification.h */,
+				0C92071F7B076D2F78266367E35DA299 /* EXPMatchers+postNotification.m */,
+				72D165B527C6B04FA62635FA695DF34C /* EXPMatchers+raise.h */,
+				A9F1435AF8F9F903D34031C41619D1D8 /* EXPMatchers+raise.m */,
+				43D8F3D174DE77DE4B86232693B09BD0 /* EXPMatchers+raiseWithReason.h */,
+				C4273C160F01D8F128DEF6AD5469CF7E /* EXPMatchers+raiseWithReason.m */,
+				202FF15792933080E43DF6C3BCDFFAFC /* EXPMatchers+respondTo.h */,
+				1A238074057C3C1262FFB1042283E274 /* EXPMatchers+respondTo.m */,
+				867D9AF4FF470DA68D363C120DB72FA6 /* EXPUnsupportedObject.h */,
+				1C4583AEB3FEB2574EC241C6DFB1A7E7 /* EXPUnsupportedObject.m */,
+				5908EB1D8C9A560497B037792FCA3E12 /* NSObject+Expecta.h */,
+				41C3C6F32FCB975511D64FED50808F68 /* NSValue+Expecta.h */,
+				39A8A444600147CF4FD261431427F59F /* NSValue+Expecta.m */,
+				C116C1554BE53CA125E477B5FB1E3294 /* Support Files */,
+			);
+			path = Expecta;
+			sourceTree = "<group>";
+		};
+		64BF0502059F410755C2AB59D8172633 /* MAObjCRuntime */ = {
+			isa = PBXGroup;
+			children = (
+				6BCC7698FC5E579C04A61927C14ABB1C /* MARTNSObject.h */,
+				0C002BF73CF9ED768EC47A919CD0B7B8 /* MARTNSObject.m */,
+				1C374A2B748E32B91C4451F28EC52A41 /* RTIvar.h */,
+				75935C78F1DA4FD81E06F4E3928E514B /* RTIvar.m */,
+				6E8E503534AB88BE13BAE3C1E9D9577B /* RTMethod.h */,
+				BC298EF491113D68B9F125ED633F3073 /* RTMethod.m */,
+				AC3EC58E73C4FD397442C88C140EA6B9 /* RTProperty.h */,
+				32BB5BC09F3C0D17A752244A07F34C15 /* RTProperty.m */,
+				6E41157E661E63C9548727BBE60EE4A1 /* RTProtocol.h */,
+				3558F8D47EDEE3265CFC4E49AF263025 /* RTProtocol.m */,
+				0F4E141AC4C5452BDF7C20C57881C711 /* RTUnregisteredClass.h */,
+				480CFE354137A41FA155677A165D6F81 /* RTUnregisteredClass.m */,
+				BBD07E759D8E311F37084DEDA5E13937 /* Support Files */,
+			);
+			path = MAObjCRuntime;
+			sourceTree = "<group>";
+		};
+		6BC038CE2E4121A9F1DF50B55B8C0307 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				D52DB94783212DD28C11307030370DFE /* TPLBatchDetails.h */,
+				FCE5230B87A0E4745AF4A6106015F45A /* TPLBatchDetails.m */,
+				AFD1A4872CB7470298D32DC943DB40CC /* TPLConstants.h */,
+				5F9920388BF7E9BA120AB890585385BD /* TPLDeviceInfo.h */,
+				1E7256A26D59AE3CAC26C8D4C479883C /* TPLDeviceInfo.m */,
+				2D914C8F02F68FE6FDED7AC68199CC64 /* TPLEvent.h */,
+				C67017CE1BD11A06E84EA27AB3D291F3 /* TPLEvent.m */,
+				9F782B9DEA7183C5D0ACF08414A92205 /* TPLFieldGroup.h */,
+				A4B4272766A9E7112FE2C1938F60E1E4 /* TPLFieldGroup.m */,
+				56153DFCF729A0275377DD7B9F669E07 /* TPLHeader.h */,
+				1DC9C6CA0D0BB185FA3F0CDF859C823F /* TPLHeader.m */,
+				D9D475117EC54B7ECA993740AFB82D17 /* Tropicalytics.h */,
+				72030FC356763407445C4C16E26E804B /* Tropicalytics.m */,
+				44B8A9DD36DDE9C4AA7E8DE4AB743AE9 /* APIClient */,
+				3DBAE87581DC41D1B2286B47D8B52781 /* Config */,
+				D0FF025BB5F3BC173C259810A454F89A /* Database */,
+				FD551644E5279975A28D14B24A29A77C /* Request Manager */,
+				D531701B81045A28E19BD738F956B8C2 /* Tropicalytics.xcdatamodeld */,
+				8DAFC339CF15A5E165AFE577284178C5 /* UniqueIdentifier */,
+				3096E8A9BF15B8AD1F2C70946F70CACB /* Utilities */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		745A9E0954268DB21A3B89D66E70F042 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CEE427098396C593D40404C4677072AB /* AFNetworking.framework */,
+				522503F048F86DB8B3FC6EF36BEBE6BB /* Expecta.framework */,
+				3F5D9459A3E51F32781F3DE3C78A7BC3 /* MAObjCRuntime.framework */,
+				A4E58C232854B6285AEF18F572A5C7E2 /* Pods_Tropicalytics_Example.framework */,
+				8630638A604C4758596FE7FAE50837E8 /* Pods_Tropicalytics_Tests.framework */,
+				1858124E2B51C0A1B46A86524BCBC335 /* Specta.framework */,
+				736825C14AB0DC5059B2304F01FCE599 /* Tropicalytics.bundle */,
+				F66A3AD5F3C42945C074B85D70D879CB /* Tropicalytics.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7DB346D0F39D3F0E887471402A8071AB = {
+			isa = PBXGroup;
+			children = (
+				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
+				4EF2BE21F5418278F7ACF4FCEEE50C24 /* Development Pods */,
+				9A478F3954470896B1F7B1DFEA20EFCC /* Frameworks */,
+				97C190EB5CB86BF601DAC63E0EB96045 /* Pods */,
+				745A9E0954268DB21A3B89D66E70F042 /* Products */,
+				1B31EDB57B03D10E1F55BE56C8E55A94 /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		7C1CAB2EB5571C81C912FAE7 /* Support Files */ = {
+		85F6D6690EA884E8641ADB15D07827E7 /* Pods-Tropicalytics_Tests */ = {
 			isa = PBXGroup;
 			children = (
-				6F83707433D8FD279F42D0F8 /* Info.plist */,
-				C658DEA6F43E389627613A0B /* Tropicalytics.modulemap */,
-				B1B55C8F76AC655BCAF3C7B1 /* Tropicalytics.xcconfig */,
-				3962CF5050EBE8CA3299BB3B /* Tropicalytics-dummy.m */,
-				E4D39C71E02B5C4F10EAE516 /* Tropicalytics-prefix.pch */,
-				60BF5DB5E8210AAC8C2889E7 /* Tropicalytics-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/Tropicalytics";
-			sourceTree = "<group>";
-		};
-		807FA84E019F0F7F2EACD020 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				1866D3FD164CFABAB6940471 /* Info.plist */,
-				42A3EE8F0250F2618C4C22D3 /* Specta.modulemap */,
-				0AC0FE3EC835E966AD24ED03 /* Specta.xcconfig */,
-				566E6BF0E03A7EB9CF90D1D4 /* Specta-dummy.m */,
-				E53DE92DA6363E41F24CC02A /* Specta-prefix.pch */,
-				41A8E57A599807B34D423FD0 /* Specta-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Specta";
-			sourceTree = "<group>";
-		};
-		8410B88C706B60F7A9E25979 /* Pods-Tropicalytics_Tests */ = {
-			isa = PBXGroup;
-			children = (
-				DAD9629D4D4BA56BAD0B3F52 /* Info.plist */,
-				AE9B6AEF7F634172B137BFBD /* Pods-Tropicalytics_Tests.modulemap */,
-				D341AA34F8D865255430EDF1 /* Pods-Tropicalytics_Tests-acknowledgements.markdown */,
-				E224A2754B4E64A4472FF2BE /* Pods-Tropicalytics_Tests-acknowledgements.plist */,
-				13B32ECCD74F6B513B2F5002 /* Pods-Tropicalytics_Tests-dummy.m */,
-				DC2F0662987B6246BA8EE11F /* Pods-Tropicalytics_Tests-frameworks.sh */,
-				E5346E864CD48D856BD9F8F8 /* Pods-Tropicalytics_Tests-resources.sh */,
-				77A66F090B984C6897B8D430 /* Pods-Tropicalytics_Tests-umbrella.h */,
-				DC76EBF54E48BAACC61331AF /* Pods-Tropicalytics_Tests.debug.xcconfig */,
-				9ECD3B87940A157976092A08 /* Pods-Tropicalytics_Tests.release.xcconfig */,
+				1415E6307EB1C9AADFD0EE7FAC3B3076 /* Info.plist */,
+				22C7967C918EC63390360823FB44392D /* Pods-Tropicalytics_Tests.modulemap */,
+				E5F1387418F145763DA282A84C8085F8 /* Pods-Tropicalytics_Tests-acknowledgements.markdown */,
+				7A0E1A7B30BD4B8B0D5BCC0423FBA75B /* Pods-Tropicalytics_Tests-acknowledgements.plist */,
+				27272C738519D352C4586A55F5030CEC /* Pods-Tropicalytics_Tests-dummy.m */,
+				98FFF4E23EBAA35E9CD3C73F34C574A1 /* Pods-Tropicalytics_Tests-frameworks.sh */,
+				1EEE2C90C5996C1F017C87D64A2A4BD5 /* Pods-Tropicalytics_Tests-resources.sh */,
+				8DE48683247B727F0F0219645EE1F9F5 /* Pods-Tropicalytics_Tests-umbrella.h */,
+				B0FC275883179BBF9A4E8547B8C41319 /* Pods-Tropicalytics_Tests.debug.xcconfig */,
+				66C686FBFB1C276659C7CCC3E6055D1B /* Pods-Tropicalytics_Tests.release.xcconfig */,
 			);
 			name = "Pods-Tropicalytics_Tests";
 			path = "Target Support Files/Pods-Tropicalytics_Tests";
 			sourceTree = "<group>";
 		};
-		8A3E381D9BF05600684CFB5E /* AFNetworking */ = {
+		8DAFC339CF15A5E165AFE577284178C5 /* UniqueIdentifier */ = {
 			isa = PBXGroup;
 			children = (
-				FF89B40E1C81C216876BFD4F /* AFNetworking.h */,
-				A679B231C0228113A9C315D2 /* NSURLSession */,
-				A0130ABA21D0F8DFE09D3FC7 /* Reachability */,
-				FF3BF3CF357DCA75A71226A4 /* Security */,
-				D64E9CDAAE39FCBD4D6CA391 /* Serialization */,
-				C0473B6C5CCA994E4E3F8FAC /* Support Files */,
-				041F8E7AE75A024D87E735DD /* UIKit */,
+				F3FB804742793E24AB40997E3EBB8ED9 /* TPLUniqueIdentifier.h */,
+				0FC29AF9978E2F882A5D65EB11ABDA9C /* TPLUniqueIdentifier.m */,
 			);
-			path = AFNetworking;
+			path = UniqueIdentifier;
 			sourceTree = "<group>";
 		};
-		8AE18CF051A789DD849D8A57 /* Specta */ = {
+		94DEC4A81978FD7E8F10F4B0BB80C9A2 /* NSURLSession */ = {
 			isa = PBXGroup;
 			children = (
-				680CA0770B720BA4C9CD2F41 /* Specta.h */,
-				910C046E69AEEBA66DF74648 /* SpectaDSL.h */,
-				B1AF206D12B17E2E4785EE0B /* SpectaDSL.m */,
-				70596B7CED927C124E2DC32D /* SpectaTypes.h */,
-				4B67D483F588048CA6509168 /* SpectaUtility.h */,
-				E1E43E53703EF200DE9B006A /* SpectaUtility.m */,
-				509E906421BBDD824171F348 /* SPTCallSite.h */,
-				30D87D0F333C18576CEA44D7 /* SPTCallSite.m */,
-				FCE53783B7A851C7787C2976 /* SPTCompiledExample.h */,
-				5BBBBAD93A45C160E8815637 /* SPTCompiledExample.m */,
-				C8E6726C922AA7D632E2B6D3 /* SPTExample.h */,
-				84ACE762DF816605DD792765 /* SPTExample.m */,
-				CF7ED9918505382834E5152B /* SPTExampleGroup.h */,
-				B19DC89501A2EB1FC6B63C48 /* SPTExampleGroup.m */,
-				A1D53DCF7E4F3D76B22A720A /* SPTExcludeGlobalBeforeAfterEach.h */,
-				9B5485900F678E43AF34E68C /* SPTGlobalBeforeAfterEach.h */,
-				2FBFE4DFEEC20ED6C90A6B34 /* SPTSharedExampleGroups.h */,
-				1B6DC751895CF5C228DF8618 /* SPTSharedExampleGroups.m */,
-				FC226BB352A8418B4DCB839B /* SPTSpec.h */,
-				00C61DABE4F0CA3386900F38 /* SPTSpec.m */,
-				B3BF0AF3ED1E29F5D050C387 /* SPTTestSuite.h */,
-				8A3B73FFFA0625FA531FA599 /* SPTTestSuite.m */,
-				39FB31A57E282FD7D871DDA1 /* XCTest+Private.h */,
-				54DF6FDED2050E924CD8937E /* XCTestCase+Specta.h */,
-				28F6F257054533FA29119C7D /* XCTestCase+Specta.m */,
-				807FA84E019F0F7F2EACD020 /* Support Files */,
-			);
-			path = Specta;
-			sourceTree = "<group>";
-		};
-		907E958044C3BB98E8667CD6 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				BC3D0CF411696522C554C2D2 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		9C6F03F931D27E5BC0D6F3C7 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				907E958044C3BB98E8667CD6 /* Pod */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
-		9DCADC85CECDEBCF30A25724 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E522A85E519B1BA6CA741403 /* Pods-Tropicalytics_Example */,
-				8410B88C706B60F7A9E25979 /* Pods-Tropicalytics_Tests */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		A0130ABA21D0F8DFE09D3FC7 /* Reachability */ = {
-			isa = PBXGroup;
-			children = (
-				B5DAB6263F944EADCCB1E0B3 /* AFNetworkReachabilityManager.h */,
-				0B83B094C6BEDE11A946C338 /* AFNetworkReachabilityManager.m */,
-			);
-			name = Reachability;
-			sourceTree = "<group>";
-		};
-		A679B231C0228113A9C315D2 /* NSURLSession */ = {
-			isa = PBXGroup;
-			children = (
-				1A996B6892DBB909CBB07E78 /* AFHTTPSessionManager.h */,
-				0B63D9CC7198CB373B2D25F2 /* AFHTTPSessionManager.m */,
-				5141B7F7FC247AA928E3EE8F /* AFURLSessionManager.h */,
-				C103BBAEC8839CBB13ED6FBB /* AFURLSessionManager.m */,
+				C4DF160A02BC4D99EB5BF20C1B9E1C37 /* AFHTTPSessionManager.h */,
+				92E102577061A6A34DE8A16029664F04 /* AFHTTPSessionManager.m */,
+				BD8DA0F7C54949412A8BA81A6DCDDF99 /* AFURLSessionManager.h */,
+				AB7AE0EE9DE6B46FF27123DD36EE7656 /* AFURLSessionManager.m */,
 			);
 			name = NSURLSession;
 			sourceTree = "<group>";
 		};
-		AD0C1ADD2F7FBD1CE2866073 /* Request Manager */ = {
+		97C190EB5CB86BF601DAC63E0EB96045 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E752C67574484C1E2C074746 /* TPLRequestManager.h */,
-				909F47FCF0AEB50D97E3334A /* TPLRequestManager.m */,
+				ADB3D01E7DD2748E858DCEC3BC68E7BB /* AFNetworking */,
+				638A50B2630ADE6081EFDE86E3C53FC1 /* Expecta */,
+				64BF0502059F410755C2AB59D8172633 /* MAObjCRuntime */,
+				4ADBBB723AA07BFD2A74C0BFFDABDF27 /* Specta */,
 			);
-			path = "Request Manager";
+			name = Pods;
 			sourceTree = "<group>";
 		};
-		B50081ED6B5FDA149959D6FB /* Tropicalytics.xcdatamodeld */ = {
+		9A478F3954470896B1F7B1DFEA20EFCC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				0636FFA4B1B3FAF4437A27B1 /* Tropicalytics.xcdatamodel */,
+				2315E4A1E1EA4063E89ABC988B323712 /* AFNetworking.framework */,
+				860E8360D18B7E55222AD02C6FA6866C /* MAObjCRuntime.framework */,
+				A0628AC04EC576D1C13F1A0079C57A13 /* iOS */,
 			);
-			path = Tropicalytics.xcdatamodeld;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		BC3D0CF411696522C554C2D2 /* Classes */ = {
+		A0628AC04EC576D1C13F1A0079C57A13 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				A1BA91204A11F46AD66DAB63 /* Tropicalytics.xcdatamodeld */,
+				093B78EA86E54DC4F3A1B2F947989BD8 /* CoreData.framework */,
+				9A33BF6D48242005A5EE8B489B416344 /* CoreGraphics.framework */,
+				635520C58D87AD79CE28204C04ABADFC /* Foundation.framework */,
+				FC238BFEC74E3A52A65122EF10679100 /* MobileCoreServices.framework */,
+				B24FD7D9D711C287927C6E7642219553 /* Security.framework */,
+				41EA7EE51CA28000254601EFA38F3774 /* SystemConfiguration.framework */,
+				20FF7AC81EFEBB6E722B793E7EE47F8F /* XCTest.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		AC38E9A2EAC639FF8F4021DA6969D24F /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				B7D3CE739FD62D60A1A6C12A25AD624E /* Tropicalytics.xcdatamodeld */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		C0473B6C5CCA994E4E3F8FAC /* Support Files */ = {
+		ADB3D01E7DD2748E858DCEC3BC68E7BB /* AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
-				BC12960B215034A1DC928A49 /* AFNetworking.modulemap */,
-				1C27927ECAFF35F0D646FC77 /* AFNetworking.xcconfig */,
-				CF87848F8610CD8AFE260C80 /* AFNetworking-dummy.m */,
-				7477867ED95A8B5EF55D10E8 /* AFNetworking-prefix.pch */,
-				AB068E87846BAF7695C205A2 /* AFNetworking-umbrella.h */,
-				56BF1DB7A734B532096CD190 /* Info.plist */,
+				C83E0E9D4E7A0B0813E910959CD27676 /* AFNetworking.h */,
+				94DEC4A81978FD7E8F10F4B0BB80C9A2 /* NSURLSession */,
+				CF46DC39805F531B0AB0134A36940D2F /* Reachability */,
+				5DD6B10CDE4284EE8A0EFA8154CFDBFD /* Security */,
+				CE320695A5A2DB58042CCA548D298ED2 /* Serialization */,
+				B94193E10B325D1CFF1C317620512E07 /* Support Files */,
+				02E354557C7B9D0D9BABA163CAB4E367 /* UIKit */,
+			);
+			path = AFNetworking;
+			sourceTree = "<group>";
+		};
+		B502CD19B79E529A2E5D393D2195D846 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				7FEB382CED9092B586EF9D2FCC6CE2D6 /* Info.plist */,
+				BF8A5D5FD78116FFAE774939DB19CE7D /* Tropicalytics.modulemap */,
+				C2251CFFE0AEB3F7789BCC2FA0429033 /* Tropicalytics.xcconfig */,
+				BECD7A1B03527A00FDC7416D15C3DFAD /* Tropicalytics-dummy.m */,
+				32FD0E3AEB5A5FA10271509CC6EA3E91 /* Tropicalytics-prefix.pch */,
+				4AC49A5BFE891F8DB5C468C22951E853 /* Tropicalytics-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Tropicalytics";
+			sourceTree = "<group>";
+		};
+		B56D21217C6463199D9F7C479AE03D19 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E8883EB79D821E17A15157143B3ABAFF /* Info.plist */,
+				B9398525D563222C3D2BEAF9AF2F8A1B /* Specta.modulemap */,
+				A2698707ECE89224BC884265E7F119A9 /* Specta.xcconfig */,
+				D5C62B64A0A67B6535BE66A210B01F3D /* Specta-dummy.m */,
+				3C0E3F03C9DBBF2623F15B072F8EE4EB /* Specta-prefix.pch */,
+				6C6C1BEBCFF500D96751BACC7B72955B /* Specta-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Specta";
+			sourceTree = "<group>";
+		};
+		B7B1290F18011342C080DB0770CAE702 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				0576066EFB738D9918051A5CBF34A045 /* Pod */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		B94193E10B325D1CFF1C317620512E07 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				0F8FD7DFC5C51A6A1598E1A5289BE5CA /* AFNetworking.modulemap */,
+				9E7EC431E31C96FE95D4C77B14BA468E /* AFNetworking.xcconfig */,
+				FDD6FD00CC0E9A86AD839FFB2434F08D /* AFNetworking-dummy.m */,
+				41531956376460ADF9969380716F0F4F /* AFNetworking-prefix.pch */,
+				43CF91364B7C2BE28963AAD6111E0343 /* AFNetworking-umbrella.h */,
+				36D802DFF57F88AC97E275EEC3C7C8C4 /* Info.plist */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/AFNetworking";
 			sourceTree = "<group>";
 		};
-		C3DCA1A8FB5EE07875A1A2EE /* Config */ = {
+		BBD07E759D8E311F37084DEDA5E13937 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				5D83A32FC2C4A2B0FFBB1586 /* TPLConfiguration.h */,
-				A07DA51FC8B94D21EBCD76F5 /* TPLConfiguration.m */,
-			);
-			path = Config;
-			sourceTree = "<group>";
-		};
-		CDDFE42070D2EEFD9CE5A525 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				456F0512D9F6FDF4A284118C /* CoreData.framework */,
-				BBB7D4F10D4F9DF16DEB236B /* CoreGraphics.framework */,
-				0835853FCB6A303AFD30F660 /* Foundation.framework */,
-				DA9B05EF14363EB9A43FF0C1 /* MobileCoreServices.framework */,
-				E8A55EB69AAF998F134584F7 /* Security.framework */,
-				986938D8BBB685F57B4E49A7 /* SystemConfiguration.framework */,
-				733955116C1B15ECA12EC5BF /* XCTest.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		D64E9CDAAE39FCBD4D6CA391 /* Serialization */ = {
-			isa = PBXGroup;
-			children = (
-				8917C6A8541B64650D67B2D8 /* AFURLRequestSerialization.h */,
-				BE8611F39B654CFEA26FCA8D /* AFURLRequestSerialization.m */,
-				C01E875452718AAE01C726C2 /* AFURLResponseSerialization.h */,
-				3EBAFF4C99F255B21978DFA6 /* AFURLResponseSerialization.m */,
-			);
-			name = Serialization;
-			sourceTree = "<group>";
-		};
-		D7C478DEBDBD601B06C4BB90 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				AFF189CFFE01A0508F5DB418 /* Info.plist */,
-				2AEA1B6A63F99EA6F986D094 /* MAObjCRuntime.modulemap */,
-				071D002A3DD913E005C979C5 /* MAObjCRuntime.xcconfig */,
-				663983A6EC3B773D48CC5846 /* MAObjCRuntime-dummy.m */,
-				0E3BAA578BB761F9737F65B2 /* MAObjCRuntime-prefix.pch */,
-				556E0171217F7F57C60C774F /* MAObjCRuntime-umbrella.h */,
+				BE21A7FBF8302A2512C06A938AF92D38 /* Info.plist */,
+				5ACE0D0F4A8B882E5F2B903D657E81AE /* MAObjCRuntime.modulemap */,
+				AF517D87C43C257FAFED6A2201585887 /* MAObjCRuntime.xcconfig */,
+				03DA11B266BF5D359C253F9B37068B8A /* MAObjCRuntime-dummy.m */,
+				51CD26F32E89ACC67514C52D073B184F /* MAObjCRuntime-prefix.pch */,
+				824A89C3ED13835DC40D6AF7EC2093E8 /* MAObjCRuntime-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/MAObjCRuntime";
 			sourceTree = "<group>";
 		};
-		D88CBCA78A8E9126FF156EB0 /* Classes */ = {
+		C116C1554BE53CA125E477B5FB1E3294 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				C13B712F2C99C95CE0B7E64A /* TPLBatchDetails.h */,
-				D632081029E3C14EBEFCD84D /* TPLBatchDetails.m */,
-				5EAAB4C2F45E64522DFED3E4 /* TPLDeviceInfo.h */,
-				F14F6FDF0DC1FD567543DF47 /* TPLDeviceInfo.m */,
-				208A7EDC7F79F4219AFFC096 /* TPLEvent.h */,
-				011F57642DCE843A4C73BF9D /* TPLEvent.m */,
-				BE0AF38F373EBD721FBE9DED /* TPLFieldGroup.h */,
-				58B1812F4B305CD9D33C1A72 /* TPLFieldGroup.m */,
-				33B2C32CED973C3B00D9A285 /* TPLHeader.h */,
-				F0A1820E358E26588DA5AB22 /* TPLHeader.m */,
-				487B9DF1F7659F3DA0F4373B /* Tropicalytics.h */,
-				434263D8CB3C13123AEB293B /* Tropicalytics.m */,
-				5E3C194FD392B9851E233304 /* APIClient */,
-				C3DCA1A8FB5EE07875A1A2EE /* Config */,
-				0D52594FA2683364AA5D5092 /* Database */,
-				AD0C1ADD2F7FBD1CE2866073 /* Request Manager */,
-				B50081ED6B5FDA149959D6FB /* Tropicalytics.xcdatamodeld */,
-				E5864D8019D9D92B78D6BE8D /* UniqueIdentifier */,
-				14D17A19A74CC11C8062E891 /* Utilities */,
-				8BCF01FA1C5B205600ED876E /* TPLConstants.h */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		E43FD76E9649B15302BEC821 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				8A3E381D9BF05600684CFB5E /* AFNetworking */,
-				E64F94191B2987ADC277BC69 /* Expecta */,
-				00F2A99B5FB30D71AE0D70BB /* MAObjCRuntime */,
-				8AE18CF051A789DD849D8A57 /* Specta */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		E51289AB853D94D1637D588F /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				CE162C857B9E2F73C6B4D7CB /* AFNetworking.framework */,
-				C357168F5311B6A832333B65 /* MAObjCRuntime.framework */,
-				CDDFE42070D2EEFD9CE5A525 /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E522A85E519B1BA6CA741403 /* Pods-Tropicalytics_Example */ = {
-			isa = PBXGroup;
-			children = (
-				DFB4D22D98F13570F8593DFB /* Info.plist */,
-				8209EE88A97687B21CB4E32D /* Pods-Tropicalytics_Example.modulemap */,
-				3B6BF98AFCA45F0F075C8B6A /* Pods-Tropicalytics_Example-acknowledgements.markdown */,
-				ED0390FBAA20A6E648880518 /* Pods-Tropicalytics_Example-acknowledgements.plist */,
-				F2F7F6CD08ED82222BEEFF64 /* Pods-Tropicalytics_Example-dummy.m */,
-				B77D87CB66AFF6F658080CBA /* Pods-Tropicalytics_Example-frameworks.sh */,
-				FC4BD3DCC32E6DB3E5E825B0 /* Pods-Tropicalytics_Example-resources.sh */,
-				75A42F90C34C50A133525E22 /* Pods-Tropicalytics_Example-umbrella.h */,
-				AD2A1D02AF7B57563074447F /* Pods-Tropicalytics_Example.debug.xcconfig */,
-				C67DAD95B64BBA021F7B0431 /* Pods-Tropicalytics_Example.release.xcconfig */,
-			);
-			name = "Pods-Tropicalytics_Example";
-			path = "Target Support Files/Pods-Tropicalytics_Example";
-			sourceTree = "<group>";
-		};
-		E5864D8019D9D92B78D6BE8D /* UniqueIdentifier */ = {
-			isa = PBXGroup;
-			children = (
-				ECFF2B0F995DD579E33A6684 /* TPLUniqueIdentifier.h */,
-				F542FB0AB288ED588CB8EE70 /* TPLUniqueIdentifier.m */,
-			);
-			path = UniqueIdentifier;
-			sourceTree = "<group>";
-		};
-		E64F94191B2987ADC277BC69 /* Expecta */ = {
-			isa = PBXGroup;
-			children = (
-				FA0BDF66B02A9E6A5A12A1AE /* EXPBlockDefinedMatcher.h */,
-				C56F976358846A2937E887A1 /* EXPBlockDefinedMatcher.m */,
-				DF5D304B9F727B7F78A86132 /* EXPDefines.h */,
-				EEEB876B4DDABF6126CE34DD /* EXPDoubleTuple.h */,
-				7EF1A61194C1B510BAB1E729 /* EXPDoubleTuple.m */,
-				37B065BBB6523FE9B1F8E10B /* Expecta.h */,
-				E2B2BB83C0233A07964E2110 /* ExpectaObject.h */,
-				210F3C7C2DE621E4CC313B61 /* ExpectaObject.m */,
-				CC3B4B88470623347DF8E8E5 /* ExpectaSupport.h */,
-				3189D712631A6E84025EDC22 /* ExpectaSupport.m */,
-				5BD0B4501FD5DE811F3014B6 /* EXPExpect.h */,
-				4E92958402F77E4A3A1B838B /* EXPExpect.m */,
-				ABA3474637645056E72F1AFD /* EXPFloatTuple.h */,
-				B0CC1EB89334CED2AA17A338 /* EXPFloatTuple.m */,
-				D70EEE0F84953D326186080D /* EXPMatcher.h */,
-				BFD4042AC08F1AC1FD8037C5 /* EXPMatcherHelpers.h */,
-				E9D35DF76902C02C23F51C46 /* EXPMatcherHelpers.m */,
-				7EAAC9E9A9BFC2CAA45D0F30 /* EXPMatchers.h */,
-				2B23A9F4B1F82D717702E6F0 /* EXPMatchers+beCloseTo.h */,
-				1427D83717625673C0A1AEFD /* EXPMatchers+beCloseTo.m */,
-				7F7C88071169F039744F47B6 /* EXPMatchers+beFalsy.h */,
-				8A2B330871B8E867D239E4E8 /* EXPMatchers+beFalsy.m */,
-				F97B6B05FDC9C58D3FC7FD2F /* EXPMatchers+beginWith.h */,
-				4740A2F17E245C9CDE02EBAB /* EXPMatchers+beginWith.m */,
-				36D59E204DFED60F9EDAD3B0 /* EXPMatchers+beGreaterThan.h */,
-				48D69F531C8EC48F2E3BF627 /* EXPMatchers+beGreaterThan.m */,
-				7BC3FA7EA4BF57D6AD056F0F /* EXPMatchers+beGreaterThanOrEqualTo.h */,
-				104705BD0F59239E950FF932 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
-				5AD365A0C24AA4EF0BFE8FD3 /* EXPMatchers+beIdenticalTo.h */,
-				05DFE5ABEA7809400D01A2B9 /* EXPMatchers+beIdenticalTo.m */,
-				1469BB282440C7D2A38B942D /* EXPMatchers+beInstanceOf.h */,
-				8DBF6687B23A6937124E289B /* EXPMatchers+beInstanceOf.m */,
-				FFC91C789B9C2BC425794D66 /* EXPMatchers+beInTheRangeOf.h */,
-				5DE6B8D9A1C241EFFB9D23DE /* EXPMatchers+beInTheRangeOf.m */,
-				FC6CD67E3FF2827F47E61CE9 /* EXPMatchers+beKindOf.h */,
-				0F7B782295DD49D307445211 /* EXPMatchers+beKindOf.m */,
-				5FE4227B8173725CD2B112A8 /* EXPMatchers+beLessThan.h */,
-				46C5C220234C54D9CD68B1DD /* EXPMatchers+beLessThan.m */,
-				7A758CD9237CFBD2A5DB28AF /* EXPMatchers+beLessThanOrEqualTo.h */,
-				24241EC3B511496E7152C871 /* EXPMatchers+beLessThanOrEqualTo.m */,
-				9FE671B3FA4CEF1B7B7488E5 /* EXPMatchers+beNil.h */,
-				4616C2ED7145D11FDD51CB8A /* EXPMatchers+beNil.m */,
-				525E1FDB7BCEED3C3E19C4A5 /* EXPMatchers+beSubclassOf.h */,
-				65E98278602C325075C17C41 /* EXPMatchers+beSubclassOf.m */,
-				25CDB7945C023404CEEF5B29 /* EXPMatchers+beSupersetOf.h */,
-				26C2C1D6D2854A25A06D3D0B /* EXPMatchers+beSupersetOf.m */,
-				858A113D5005570A3156446F /* EXPMatchers+beTruthy.h */,
-				EE3F8083872F8DDB4A326CF3 /* EXPMatchers+beTruthy.m */,
-				66F984F119FDD273A3D68CDB /* EXPMatchers+conformTo.h */,
-				DA577FC582254B4F55528543 /* EXPMatchers+conformTo.m */,
-				DA58047B5C03BB8E71D63823 /* EXPMatchers+contain.h */,
-				62A6AB1F67E410F9862D16A1 /* EXPMatchers+contain.m */,
-				8A44D442A8C29880368CE3CA /* EXPMatchers+endWith.h */,
-				C9844118A441FB6F0DBDF6E5 /* EXPMatchers+endWith.m */,
-				E39EB5AE93BDE3228ED3E026 /* EXPMatchers+equal.h */,
-				65F11C13F2805B175829181F /* EXPMatchers+equal.m */,
-				A128BEF7F74A4EEB7FAB14D0 /* EXPMatchers+haveCountOf.h */,
-				E7434050AC818983B34B8E30 /* EXPMatchers+haveCountOf.m */,
-				67FC358DBD87EEEBF6C9A36F /* EXPMatchers+match.h */,
-				5BFE53A21749E040B0A1F61B /* EXPMatchers+match.m */,
-				0EC96A7157C64ADB966C005D /* EXPMatchers+postNotification.h */,
-				26532C970F94CD4745741EC3 /* EXPMatchers+postNotification.m */,
-				4C3583087CBDCA96B96D9E3F /* EXPMatchers+raise.h */,
-				95F725B2E54499F16B6A74A8 /* EXPMatchers+raise.m */,
-				95732E99024A5AA921F8A5E4 /* EXPMatchers+raiseWithReason.h */,
-				08947A5715EB758FC8090AFF /* EXPMatchers+raiseWithReason.m */,
-				5DB3AF35C0B48F0B4E641E34 /* EXPMatchers+respondTo.h */,
-				D0F28D2F290D6E9BD1686CE3 /* EXPMatchers+respondTo.m */,
-				997BBC9CAB5C513CDDFF47D3 /* EXPUnsupportedObject.h */,
-				4B1ADEEB26CF0E7F2E92148B /* EXPUnsupportedObject.m */,
-				41C7DC0BE4689DB6E836040F /* NSObject+Expecta.h */,
-				1A585BED58FFC22D394D6645 /* NSValue+Expecta.h */,
-				A4B152E773A23C111F798586 /* NSValue+Expecta.m */,
-				F81AE926ADE42D3302F6F28D /* Support Files */,
-			);
-			path = Expecta;
-			sourceTree = "<group>";
-		};
-		F81AE926ADE42D3302F6F28D /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				1C1A145E74AE1448BA436275 /* Expecta.modulemap */,
-				C3D1A69BFEADD6D75EDCE592 /* Expecta.xcconfig */,
-				7D4BF1C89779AB8D8CD5C57B /* Expecta-dummy.m */,
-				06F900A63FD8EB06FA8C86BA /* Expecta-prefix.pch */,
-				61B3A585ABC8C12DEB4AEBEB /* Expecta-umbrella.h */,
-				6F8DCF81F3D10E1E334CD666 /* Info.plist */,
+				7EFDAEE9BC9F9FD933F7E554804748B0 /* Expecta.modulemap */,
+				DE3064393EAFA98ADCBB0F51F9928D61 /* Expecta.xcconfig */,
+				E46DD46C9B83578FA4AB3E4E99AA6060 /* Expecta-dummy.m */,
+				99454B3D73AD2499FD2124516E9FCA9B /* Expecta-prefix.pch */,
+				9AAE48B66D04BFE93C713663A4CD3643 /* Expecta-umbrella.h */,
+				9D12B83609131AA8AB7378C863397150 /* Info.plist */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Expecta";
 			sourceTree = "<group>";
 		};
-		FF3BF3CF357DCA75A71226A4 /* Security */ = {
+		C148A9E34F5999A108C3A5765A0FB2BF /* Pods-Tropicalytics_Example */ = {
 			isa = PBXGroup;
 			children = (
-				D53B877D0A19E2094582A8AC /* AFSecurityPolicy.h */,
-				EFF67D24A44348E86C62A187 /* AFSecurityPolicy.m */,
+				491A615DBBEEF3B99DDDE4765484534D /* Info.plist */,
+				044A233B0617BF0B3397B312CD619F02 /* Pods-Tropicalytics_Example.modulemap */,
+				B0423736FFA88FE8EA2A41E79DC2E601 /* Pods-Tropicalytics_Example-acknowledgements.markdown */,
+				DCA8D189A7F64A2E1EFEB1D492E5C9B0 /* Pods-Tropicalytics_Example-acknowledgements.plist */,
+				4EF3503053D357443A7E767A8610313E /* Pods-Tropicalytics_Example-dummy.m */,
+				0A0D6D89A0D6F0ACB4B6E9D469F72CB9 /* Pods-Tropicalytics_Example-frameworks.sh */,
+				419F70664EE5599E7899F5564A80790B /* Pods-Tropicalytics_Example-resources.sh */,
+				86BBDF325054136E536E454554BC48BB /* Pods-Tropicalytics_Example-umbrella.h */,
+				84CF0E427569F2E1E2677C6C75D1A30C /* Pods-Tropicalytics_Example.debug.xcconfig */,
+				574875DBC633C280CE29B4C5C92C3B2C /* Pods-Tropicalytics_Example.release.xcconfig */,
 			);
-			name = Security;
+			name = "Pods-Tropicalytics_Example";
+			path = "Target Support Files/Pods-Tropicalytics_Example";
+			sourceTree = "<group>";
+		};
+		CE320695A5A2DB58042CCA548D298ED2 /* Serialization */ = {
+			isa = PBXGroup;
+			children = (
+				093B510C608944D5C2F42932F5BA6070 /* AFURLRequestSerialization.h */,
+				D3501FFC901C55619F1B7B16AFC662AC /* AFURLRequestSerialization.m */,
+				3A97EB4033E95E3C23ABCDA4A9BBB023 /* AFURLResponseSerialization.h */,
+				320E4F1C0A54C8EDCDB43A020085444E /* AFURLResponseSerialization.m */,
+			);
+			name = Serialization;
+			sourceTree = "<group>";
+		};
+		CF46DC39805F531B0AB0134A36940D2F /* Reachability */ = {
+			isa = PBXGroup;
+			children = (
+				BAE57C33490B0B1AF6088B01E11F886A /* AFNetworkReachabilityManager.h */,
+				62B05FDD26E59490F648E62593C27DAB /* AFNetworkReachabilityManager.m */,
+			);
+			name = Reachability;
+			sourceTree = "<group>";
+		};
+		D0FF025BB5F3BC173C259810A454F89A /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				D8E869FEDAEF2E552F5461B57AFD21B1 /* TPLDatabase.h */,
+				C9C5C1888711FD6E2DF19960C63234BF /* TPLDatabase.m */,
+			);
+			path = Database;
+			sourceTree = "<group>";
+		};
+		D531701B81045A28E19BD738F956B8C2 /* Tropicalytics.xcdatamodeld */ = {
+			isa = PBXGroup;
+			children = (
+				F85058AEE36647CC0D6A5DE2DD6F8B07 /* Tropicalytics.xcdatamodel */,
+			);
+			path = Tropicalytics.xcdatamodeld;
+			sourceTree = "<group>";
+		};
+		F85058AEE36647CC0D6A5DE2DD6F8B07 /* Tropicalytics.xcdatamodel */ = {
+			isa = PBXGroup;
+			children = (
+				A8C8BD49A285284CD8ACC1CC30EA3D08 /* contents */,
+			);
+			path = Tropicalytics.xcdatamodel;
+			sourceTree = "<group>";
+		};
+		FD551644E5279975A28D14B24A29A77C /* Request Manager */ = {
+			isa = PBXGroup;
+			children = (
+				129291D583AF85C58E9D5336C8110C60 /* TPLRequestManager.h */,
+				474AF8A86F5D81BFBA1AAC0698EA3A5E /* TPLRequestManager.m */,
+			);
+			path = "Request Manager";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		17DF8ADA001E66C067455F6F /* Headers */ = {
+		2F2CE9EFDEAE59F21BD87EC36534E4A1 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6D738BF67CFC52D02743E6E /* Specta-umbrella.h in Headers */,
-				2885A6C75D33FE480D4A5428 /* Specta.h in Headers */,
-				9384A1EA0BE4E8E050801EFC /* SpectaDSL.h in Headers */,
-				5F2B7EDA050A9B8A9655C5F1 /* SpectaTypes.h in Headers */,
-				E77ACCD76B94932DF054F481 /* SpectaUtility.h in Headers */,
-				F8FB0DDA33255623634A06B8 /* SPTCallSite.h in Headers */,
-				795DD6B08D6369C660E7BD97 /* SPTCompiledExample.h in Headers */,
-				7E1B6C2F76E7B76CD94E329E /* SPTExample.h in Headers */,
-				F45D6ED8583D3B61F106D71E /* SPTExampleGroup.h in Headers */,
-				BB2577CF155F9E58F2FCAED3 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
-				A1837871382CEF86D83FE0EE /* SPTGlobalBeforeAfterEach.h in Headers */,
-				E0E510ED902CEA9CDF509A51 /* SPTSharedExampleGroups.h in Headers */,
-				9D6224B9A81E4EBCDAB79CF8 /* SPTSpec.h in Headers */,
-				1250A6246828A95D911AB82B /* SPTTestSuite.h in Headers */,
-				ABA0EEFE007B82165947377E /* XCTest+Private.h in Headers */,
-				57254D2B9B30C4725C0BE6B5 /* XCTestCase+Specta.h in Headers */,
+				A55368BBDD7417464F40151C5F9B6A09 /* MAObjCRuntime-umbrella.h in Headers */,
+				536293D7AF840017A21EC63E1B811A2E /* MARTNSObject.h in Headers */,
+				553B6989768B187B16B1E127D813AE20 /* RTIvar.h in Headers */,
+				689D42AF6D9D42F36E2E31CDC25978B7 /* RTMethod.h in Headers */,
+				78A09642B8D3048606BCE3CDC2019071 /* RTProperty.h in Headers */,
+				021186FE99D6975FAE757AC8E46558D1 /* RTProtocol.h in Headers */,
+				2810F816A41B60EC24C3D882D83AF212 /* RTUnregisteredClass.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2615F0286D88C4B010C15100 /* Headers */ = {
+		4F27CB4D76B9A86E0ECEC60C3BBE2666 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E0E1D1DD1AA8E869F44CB7B3 /* MAObjCRuntime-umbrella.h in Headers */,
-				B3AF6A826FA227A8B11D38D9 /* MARTNSObject.h in Headers */,
-				AD36E1C96C491A74B360490A /* RTIvar.h in Headers */,
-				FC97F17129269651E642A806 /* RTMethod.h in Headers */,
-				17E08527CAE68D0EF114D3A0 /* RTProperty.h in Headers */,
-				AB1DA5551DD012FA23D37791 /* RTProtocol.h in Headers */,
-				B3CE9C99D45D37DD6B945502 /* RTUnregisteredClass.h in Headers */,
+				E69E67C39F4340EE7690A1110217B7AA /* TPLAPIClient.h in Headers */,
+				2343A10BA5F34DBCEAF0C4D7AA6CA951 /* TPLAppUtilities.h in Headers */,
+				D095DAFFC0228BEB9473245C48AC2C86 /* TPLBatchDetails.h in Headers */,
+				6095B07F1C2B84B967C0A5CE012C0EBA /* TPLConfiguration.h in Headers */,
+				6712C24A9D9DFFDCEAB6BAF3D5B0EB8A /* TPLConstants.h in Headers */,
+				5CD5F64603D7BAC8072AB6F4936C30F9 /* TPLDatabase.h in Headers */,
+				31DE08E2C2F98427FB92272F0888C9C4 /* TPLDeviceInfo.h in Headers */,
+				995A898987821ED94ACC9FB6BE68293D /* TPLDeviceUtilities.h in Headers */,
+				2E58192A60F2DC4F7B426B6DAA8F6689 /* TPLEvent.h in Headers */,
+				FE635A989AD51FDD5A957911BE281527 /* TPLFieldGroup.h in Headers */,
+				59F17B09B955685C482CCFEA106D81B1 /* TPLHeader.h in Headers */,
+				F12A0C603FDA2FDECB63BE324E043ED7 /* TPLRequestManager.h in Headers */,
+				C453B6E83975F6663D3F1C33CB3B5E03 /* TPLUniqueIdentifier.h in Headers */,
+				9B913DE1C355BCE97D2EDA90D3AA5FC1 /* TPLUtilities.h in Headers */,
+				87E76C70F7F2EE1EE2AAE992DD63B9F1 /* Tropicalytics-umbrella.h in Headers */,
+				E0B6A9C0D66D2EB745DC11B08236C1B1 /* Tropicalytics.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		536B89255CCB7544D94C2A97 /* Headers */ = {
+		4F7B4C347AB1AB77D1F5FDF9D96BC3B5 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7CC7C077BA1ADAD0DE14AC7 /* AFAutoPurgingImageCache.h in Headers */,
-				AF5859CD39CCBF05B22D008A /* AFHTTPSessionManager.h in Headers */,
-				4C5971BD5BB3660DE59DA319 /* AFImageDownloader.h in Headers */,
-				056B7DD13B3F4C729FDE9716 /* AFNetworkActivityIndicatorManager.h in Headers */,
-				0C3E038B7EAFA5CFDA27ADF9 /* AFNetworking-umbrella.h in Headers */,
-				934A1938E158486A4D8DA0AC /* AFNetworking.h in Headers */,
-				6D496F354BB4EE1C95B778E3 /* AFNetworkReachabilityManager.h in Headers */,
-				F20C788E5B9929B537A664B2 /* AFSecurityPolicy.h in Headers */,
-				A5507844E83D04ACD8720C86 /* AFURLRequestSerialization.h in Headers */,
-				7747C73060E9E2F071DDDEC8 /* AFURLResponseSerialization.h in Headers */,
-				6F326303534A55CDCC5D4C7E /* AFURLSessionManager.h in Headers */,
-				DC37A8533021B532383B5171 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
-				9A1A5BA25FD7ED5A13371A27 /* UIButton+AFNetworking.h in Headers */,
-				316634BD1099A53F22246904 /* UIImage+AFNetworking.h in Headers */,
-				C6DC2CCC2143FD9C8F24D806 /* UIImageView+AFNetworking.h in Headers */,
-				67F9D799C25CC66B030B19A9 /* UIKit+AFNetworking.h in Headers */,
-				D8D034D16583D37E17C34222 /* UIProgressView+AFNetworking.h in Headers */,
-				241E1090BA19D89EEBA0D73D /* UIRefreshControl+AFNetworking.h in Headers */,
-				23E1E921FD137D1856CA7AD1 /* UIWebView+AFNetworking.h in Headers */,
+				DC10E3D4436CBE4952C670687B2216B2 /* Pods-Tropicalytics_Example-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8511CE78576E083BE5B89505 /* Headers */ = {
+		5CDF07A95AFF678D3836B9CF0F96E10C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCE56CC457D00834AF488527 /* Pods-Tropicalytics_Example-umbrella.h in Headers */,
+				D2A4247F3B0B92D1D67C1C18F4E05371 /* Specta-umbrella.h in Headers */,
+				74EF67DE380915006A15DD206DBB3A6E /* Specta.h in Headers */,
+				B05DD383D9D1887FD8F83A8D7415A095 /* SpectaDSL.h in Headers */,
+				12F95AEFF8EB3F9ED139C6D26B9C8264 /* SpectaTypes.h in Headers */,
+				F09FCC00653002D3E8C1CA1642AAE20F /* SpectaUtility.h in Headers */,
+				33BC013B3C8F98E74D039CB62CBBFBC6 /* SPTCallSite.h in Headers */,
+				EE4493053DB8B45C30681D9199FE9E2A /* SPTCompiledExample.h in Headers */,
+				164B2A363F9B0096A792A69320A30D42 /* SPTExample.h in Headers */,
+				40583F11C8BEB933BFC82864F7C2869C /* SPTExampleGroup.h in Headers */,
+				C00782B6CD46D9EB56C5F8DBD892DC93 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
+				5BAD8306315E116F6E8E76552EC5B665 /* SPTGlobalBeforeAfterEach.h in Headers */,
+				341F8F1652A7DE6AADAA3331CA6320CB /* SPTSharedExampleGroups.h in Headers */,
+				F37470070FB9192B6923FB2ADCF5C6D7 /* SPTSpec.h in Headers */,
+				F845FE027C41B7FF67C2BACDC16CC23E /* SPTTestSuite.h in Headers */,
+				57C82EC703961B78511B46C6EEBB70A7 /* XCTest+Private.h in Headers */,
+				8F3C7283335959E7FBFD25BDC7B376CD /* XCTestCase+Specta.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8E6C53FFEFB03CD7DFB5884F /* Headers */ = {
+		6122C7B205E5C001D36B1CA204A7C259 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A96F4B9C1FA6FEA0D692ECE2 /* Pods-Tropicalytics_Tests-umbrella.h in Headers */,
+				2D092F28EA53CA81B80CB84636B25931 /* Pods-Tropicalytics_Tests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A61432F6BC1895CD8B865290 /* Headers */ = {
+		7C6A0D99A9CC32A19A92A62F8A941139 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				40F8DD028674197F6A4E2CCA /* EXPBlockDefinedMatcher.h in Headers */,
-				A53A4345D0EFEFE92E2E9503 /* EXPDefines.h in Headers */,
-				EDF7118AF1E0ECA3A4A871EA /* EXPDoubleTuple.h in Headers */,
-				49DABA58DA4B4E269214DF12 /* Expecta-umbrella.h in Headers */,
-				82A753A120047D77A55D0D43 /* Expecta.h in Headers */,
-				C69944832128E0297F97E30D /* ExpectaObject.h in Headers */,
-				33BD4F03450067C3C3CFD701 /* ExpectaSupport.h in Headers */,
-				24FCD0B7B3989164E5BDFDDA /* EXPExpect.h in Headers */,
-				FA02E63B6C365FA887C3B580 /* EXPFloatTuple.h in Headers */,
-				75C438C001E474B1C9DCBD99 /* EXPMatcher.h in Headers */,
-				F5E8D6BC15D7DEB6EAEE884D /* EXPMatcherHelpers.h in Headers */,
-				1FD11FD0AEDA68573C6BBA27 /* EXPMatchers+beCloseTo.h in Headers */,
-				41824E118024B17B9D2C4015 /* EXPMatchers+beFalsy.h in Headers */,
-				0F086340CC987F003CA20279 /* EXPMatchers+beginWith.h in Headers */,
-				093351E005568BF0FA11777B /* EXPMatchers+beGreaterThan.h in Headers */,
-				2C579E66B64D000BDD78FAAF /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */,
-				31AEDA77CEF1135DD1E36557 /* EXPMatchers+beIdenticalTo.h in Headers */,
-				7CCDB781E1008042A0A8D860 /* EXPMatchers+beInstanceOf.h in Headers */,
-				E44C58BD141ACDF5FA588E21 /* EXPMatchers+beInTheRangeOf.h in Headers */,
-				5EF95D55C34E5CEC7344B0C3 /* EXPMatchers+beKindOf.h in Headers */,
-				0F344222BC9A2B41DA0F0226 /* EXPMatchers+beLessThan.h in Headers */,
-				3D387D5C23A90EC765FC1F54 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */,
-				0CEE09D4EC7ED0A43D3338D1 /* EXPMatchers+beNil.h in Headers */,
-				88CBCF20D64B60780E529366 /* EXPMatchers+beSubclassOf.h in Headers */,
-				8360DE581CC521CF79BA3658 /* EXPMatchers+beSupersetOf.h in Headers */,
-				D283EE2DA9DB1FA29BB1C6E8 /* EXPMatchers+beTruthy.h in Headers */,
-				F1CE4D94F69D0D09D927C2EF /* EXPMatchers+conformTo.h in Headers */,
-				9A4D08E675946FBEA740170E /* EXPMatchers+contain.h in Headers */,
-				1CA1876F4ADC44D49F626782 /* EXPMatchers+endWith.h in Headers */,
-				D96E1F72977CFD08AECEFAA6 /* EXPMatchers+equal.h in Headers */,
-				3A8AF6F36002CC9A750D788B /* EXPMatchers+haveCountOf.h in Headers */,
-				F0AC18D774E52FB27F0AEB7E /* EXPMatchers+match.h in Headers */,
-				11B8720804CA4C75D2C51404 /* EXPMatchers+postNotification.h in Headers */,
-				826A58B59A7F3595575C4CED /* EXPMatchers+raise.h in Headers */,
-				FC8E9F69D55776B4C93D1C21 /* EXPMatchers+raiseWithReason.h in Headers */,
-				AFFEB547694ECCB37DD2F4BF /* EXPMatchers+respondTo.h in Headers */,
-				6C7D8B3FE8AD7BC85096EF64 /* EXPMatchers.h in Headers */,
-				3DCCC3D674E44F9574DFCF4D /* EXPUnsupportedObject.h in Headers */,
-				73C09D5A01CC91BDE7FAFAC7 /* NSObject+Expecta.h in Headers */,
-				6DCBA87E171E13440D7C4092 /* NSValue+Expecta.h in Headers */,
+				CAC483EF637FB4A2C2E2FC75BA631B87 /* AFAutoPurgingImageCache.h in Headers */,
+				AB39AC9746E7575D7449700475E41B0B /* AFHTTPSessionManager.h in Headers */,
+				5808B477EFF509D810B5CDCFDC944F80 /* AFImageDownloader.h in Headers */,
+				1480F4923DBBF217F60572EEECB4027C /* AFNetworkActivityIndicatorManager.h in Headers */,
+				EC7CADE416A78A1CD6936018A6695126 /* AFNetworking-umbrella.h in Headers */,
+				E7988678C81F7CCB95D239375FC6986D /* AFNetworking.h in Headers */,
+				68152D921ABF6A423C192C04FDF94F0F /* AFNetworkReachabilityManager.h in Headers */,
+				C2DD28375E1F0B1D0D1D2E4E607C499F /* AFSecurityPolicy.h in Headers */,
+				20EE8030FCF2402DAC7F1C9B9DDAEF79 /* AFURLRequestSerialization.h in Headers */,
+				7332F15718920917F544F35CE2C038AA /* AFURLResponseSerialization.h in Headers */,
+				560698A4D707DCBCC1C8F98BC9B89B23 /* AFURLSessionManager.h in Headers */,
+				1E5B8F12ED7CC40ECDB9B1F755F387E5 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
+				81B617F8D26BB10C5726D75E85D21EB7 /* UIButton+AFNetworking.h in Headers */,
+				9E1E90DED74B73ECE53C9AD76DE53E2D /* UIImage+AFNetworking.h in Headers */,
+				60E3009342BEE96D32C546BE2DB60052 /* UIImageView+AFNetworking.h in Headers */,
+				659960F7E28E993E08CCC1E8A383E710 /* UIKit+AFNetworking.h in Headers */,
+				D9F4E833E37B611B432F6B5D7072DDA2 /* UIProgressView+AFNetworking.h in Headers */,
+				C6354FEC7728A4C86DAD8092509BA7D4 /* UIRefreshControl+AFNetworking.h in Headers */,
+				AE2A07407FB50BA249984DC0620E84C0 /* UIWebView+AFNetworking.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CCDEAB85338FB1014C080BB3 /* Headers */ = {
+		966427BD32145AD621F074D1691342B8 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8D623417321B2243EABED62D /* TPLAPIClient.h in Headers */,
-				71559A36DF45943FE3DF6A58 /* TPLAppUtilities.h in Headers */,
-				376C669BB6856EFABAA90FF7 /* TPLBatchDetails.h in Headers */,
-				280708F7C8BA5065E3F5F9F1 /* TPLConfiguration.h in Headers */,
-				59DBC14E1DC5B8D8F67789C2 /* TPLDatabase.h in Headers */,
-				2DD6291617A3F05AC8D82492 /* TPLDeviceInfo.h in Headers */,
-				A7C644B889C64CA44B60F320 /* TPLDeviceUtilities.h in Headers */,
-				D05105A05247EE7AEDD236EC /* TPLEvent.h in Headers */,
-				A60D57D64D21A2FBB520E304 /* TPLFieldGroup.h in Headers */,
-				49C48575D0C8BFC6D9FEF382 /* TPLHeader.h in Headers */,
-				9A2496E900860885C69C218F /* TPLRequestManager.h in Headers */,
-				02EE5D844540CEBAF8673966 /* TPLUniqueIdentifier.h in Headers */,
-				058A61443BDD2224E8EAD706 /* TPLUtilities.h in Headers */,
-				960E6A7C800214C17FC3E16C /* Tropicalytics-umbrella.h in Headers */,
-				8BCF01FB1C5B205600ED876E /* TPLConstants.h in Headers */,
-				8712716F65C7E6FA1BBA5456 /* Tropicalytics.h in Headers */,
+				3B5B7495707BF7133B9FB3F834045611 /* EXPBlockDefinedMatcher.h in Headers */,
+				5EA7043FE10E75D02F3C3052AF8B8318 /* EXPDefines.h in Headers */,
+				2F427490ACABC4408D57CC0592276678 /* EXPDoubleTuple.h in Headers */,
+				837B593D7C1D01B4EA400247309D6AB0 /* Expecta-umbrella.h in Headers */,
+				E1EC4532663CA75DE5BD00CB0A56814D /* Expecta.h in Headers */,
+				2E14619153A453BB8DF389FB6EA147BE /* ExpectaObject.h in Headers */,
+				AFFC8900E52BBEC72059334132F3A8F3 /* ExpectaSupport.h in Headers */,
+				67459AD239EF669A365519E06B45DCFE /* EXPExpect.h in Headers */,
+				6E1D978790705E137FDE439AA68DD3AA /* EXPFloatTuple.h in Headers */,
+				65BC31095CCDFC80CBF6BBA843751F23 /* EXPMatcher.h in Headers */,
+				8C8C1B0D83FE6A4352F15154DB16372C /* EXPMatcherHelpers.h in Headers */,
+				AF1F46668D4591602887998C6E9C10AD /* EXPMatchers+beCloseTo.h in Headers */,
+				F41209A94070904A00BDF24ACB6336B6 /* EXPMatchers+beFalsy.h in Headers */,
+				FD2D4497BC41412128C2D87C1BDE7398 /* EXPMatchers+beginWith.h in Headers */,
+				6EFC63A5CED45BB39FC79D87F2C47D6B /* EXPMatchers+beGreaterThan.h in Headers */,
+				372F7A9CCE59CE86316CF436F832A3FC /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */,
+				E0AAF49134A0505DF00E20E7B62087E1 /* EXPMatchers+beIdenticalTo.h in Headers */,
+				34B6E9A30603BEBBD87BA535B7D384CA /* EXPMatchers+beInstanceOf.h in Headers */,
+				131532787AD40BE1F35DF288D2E6FFD7 /* EXPMatchers+beInTheRangeOf.h in Headers */,
+				79558B1F97ABE4AB8942DC18BEBD4B82 /* EXPMatchers+beKindOf.h in Headers */,
+				0D16B556212D317A0D4FEB71E102E207 /* EXPMatchers+beLessThan.h in Headers */,
+				37A2D0F8493469EF2495FC689440F079 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */,
+				E735386085CE344F6A01178CF4763852 /* EXPMatchers+beNil.h in Headers */,
+				397B320B7C59C168CC5B62E18ED8DEA0 /* EXPMatchers+beSubclassOf.h in Headers */,
+				76CCABE79C04444450153424D7CE1DC1 /* EXPMatchers+beSupersetOf.h in Headers */,
+				85EB2F216487CB2E8F3FCCFBC4D69912 /* EXPMatchers+beTruthy.h in Headers */,
+				F0DDF02A078B917997FF025BB33BB842 /* EXPMatchers+conformTo.h in Headers */,
+				3C2700C7DAA15C6AF84A595865C42F4D /* EXPMatchers+contain.h in Headers */,
+				1A1AB2EC52323C5EA28DAA99F1E1A90D /* EXPMatchers+endWith.h in Headers */,
+				0F94F5B0ABB3252B9275B7C129EC7A26 /* EXPMatchers+equal.h in Headers */,
+				F75CB2A727F678C9A848A3A11EA7979B /* EXPMatchers+haveCountOf.h in Headers */,
+				2916A0606136A9DC67F2463AB230868B /* EXPMatchers+match.h in Headers */,
+				9B2E761A064459F77EA9870BEF03ACC3 /* EXPMatchers+postNotification.h in Headers */,
+				46137F5CC368BF38BAF0D0AF81DD8FFE /* EXPMatchers+raise.h in Headers */,
+				11C1AEB289C1EB80089349B71F09D04B /* EXPMatchers+raiseWithReason.h in Headers */,
+				260BC7EED9289AF321A6F791964CE472 /* EXPMatchers+respondTo.h in Headers */,
+				85E31076D5530AEEB45ACF16B2B8A983 /* EXPMatchers.h in Headers */,
+				51DDDB0FB4899757CF6A826B531B940D /* EXPUnsupportedObject.h in Headers */,
+				7B223B4E6EF14BA12DA113F7EE10B96C /* NSObject+Expecta.h in Headers */,
+				471FD4F68E27AB26FA2AEBB8B245CEE4 /* NSValue+Expecta.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		344CD463CAA283D595371E33 /* Tropicalytics-Tropicalytics */ = {
+		0D888F29E05E498D0CD91A51D28599A5 /* Expecta */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F1E4180DBD5C0AD48AADE62A /* Build configuration list for PBXNativeTarget "Tropicalytics-Tropicalytics" */;
+			buildConfigurationList = DC61702A42844E4ED762A73E8893436B /* Build configuration list for PBXNativeTarget "Expecta" */;
 			buildPhases = (
-				96E033C6D1627AC145025B62 /* Sources */,
-				5B43E9AC9AFDD307D4D804AD /* Frameworks */,
-				9193FBE7DDE3CA32B5CC5370 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Tropicalytics-Tropicalytics";
-			productName = "Tropicalytics-Tropicalytics";
-			productReference = E78EA460EFD8BA9241DCCA56 /* Tropicalytics.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
-		555C0DCF4037F17BB7332590 /* Specta */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DF9DB3DE873965683A3E9096 /* Build configuration list for PBXNativeTarget "Specta" */;
-			buildPhases = (
-				DBF552DCEF2B086768A0B005 /* Sources */,
-				57CECD599106EA0821E86D71 /* Frameworks */,
-				17DF8ADA001E66C067455F6F /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Specta;
-			productName = Specta;
-			productReference = 149FB071D5A9B00862C1C10A /* Specta.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		84D5D9A22D32015D8E08133F /* Pods-Tropicalytics_Example */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9413B104FFE5DFAC9D5C5B9B /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Example" */;
-			buildPhases = (
-				E6C3374E900FE6D140FB0CF7 /* Sources */,
-				D50F20778358933676A493C9 /* Frameworks */,
-				8511CE78576E083BE5B89505 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				8B6B65114EA4E3888F22C4C6 /* PBXTargetDependency */,
-				24DB3324E7B86C01AB014266 /* PBXTargetDependency */,
-				7EB4FA2DAE5EFA9B180DF85F /* PBXTargetDependency */,
-			);
-			name = "Pods-Tropicalytics_Example";
-			productName = "Pods-Tropicalytics_Example";
-			productReference = 6BDFE707A23940C4E60396BF /* Pods_Tropicalytics_Example.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		901977407F28FD34ED7BD7ED /* AFNetworking */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 5E024355FC2629788DA738B0 /* Build configuration list for PBXNativeTarget "AFNetworking" */;
-			buildPhases = (
-				8DBC65589318CE17065FB02F /* Sources */,
-				7602D1E66F24D14A1AB4EAFE /* Frameworks */,
-				536B89255CCB7544D94C2A97 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = AFNetworking;
-			productName = AFNetworking;
-			productReference = 381BD6E0206D8212754AD170 /* AFNetworking.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		A4CA4C94B10CA708DEC0F48B /* MAObjCRuntime */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CF01AC83F0DBAF75B78EA34F /* Build configuration list for PBXNativeTarget "MAObjCRuntime" */;
-			buildPhases = (
-				0FC7CE59C0D54DFFA4ED9432 /* Sources */,
-				4476D762CE860E5BDBC531D4 /* Frameworks */,
-				2615F0286D88C4B010C15100 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = MAObjCRuntime;
-			productName = MAObjCRuntime;
-			productReference = 2D1C1FA95148C00B5C0EE315 /* MAObjCRuntime.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		CA2488A6AAF184795C789D52 /* Expecta */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = E897CF271FA1DB0D2107516D /* Build configuration list for PBXNativeTarget "Expecta" */;
-			buildPhases = (
-				C794149434AA8A3E335870FA /* Sources */,
-				FE4C4B9AD57AA88725EAFF5E /* Frameworks */,
-				A61432F6BC1895CD8B865290 /* Headers */,
+				B239BD93C67DE976C7F3A1AD982A0A58 /* Sources */,
+				E6B836B352B13C63D3C0FA0E500C98A4 /* Frameworks */,
+				966427BD32145AD621F074D1691342B8 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1415,533 +1328,411 @@
 			);
 			name = Expecta;
 			productName = Expecta;
-			productReference = 16C68FCC6AFEDA88107C10FD /* Expecta.framework */;
+			productReference = 522503F048F86DB8B3FC6EF36BEBE6BB /* Expecta.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D3505E04070EDD818D3D70A8 /* Tropicalytics */ = {
+		1C3436CEA5C3D39764C5F54374794ECB /* AFNetworking */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2DAAC0B40E69F5DDC5AF4161 /* Build configuration list for PBXNativeTarget "Tropicalytics" */;
+			buildConfigurationList = 57800A0D1724774333EF09E83030AA81 /* Build configuration list for PBXNativeTarget "AFNetworking" */;
 			buildPhases = (
-				F6EDA88643495C343AFDA136 /* Sources */,
-				DD4F030FBA0C3B0A8F7E6C8D /* Frameworks */,
-				C0AF2F2B70EB8B371B9C4D0C /* Resources */,
-				CCDEAB85338FB1014C080BB3 /* Headers */,
+				1F17F426378DF5EC8DFB10304B8C4BA4 /* Sources */,
+				C151364F15F39F7CC60CBF9A3AB49B44 /* Frameworks */,
+				7C6A0D99A9CC32A19A92A62F8A941139 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				8FFC161691AC0DB8ABA02939 /* PBXTargetDependency */,
-				D4E5739D606D9A5565DE6B4F /* PBXTargetDependency */,
-				8F8F9D44EE0B0985EBFDBE92 /* PBXTargetDependency */,
+			);
+			name = AFNetworking;
+			productName = AFNetworking;
+			productReference = CEE427098396C593D40404C4677072AB /* AFNetworking.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2E506988AC2C89E31E46A3E227C81671 /* Tropicalytics */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 95C0E83C4364C98EA972AAFC120419B3 /* Build configuration list for PBXNativeTarget "Tropicalytics" */;
+			buildPhases = (
+				BFAA8C7F4D04651847AEB37B750C163B /* Sources */,
+				95182BB079148AFF271DF4753F745FB8 /* Frameworks */,
+				2CD1F995B882FA8E9DEA0BF06E2E4DD4 /* Resources */,
+				4F27CB4D76B9A86E0ECEC60C3BBE2666 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CBAAE057770D1D95F89E40B9FAF98BA4 /* PBXTargetDependency */,
+				903DD9CE23247874822F61A8B4CC18A7 /* PBXTargetDependency */,
+				AD1C2D7E43247C25292589D799673AF5 /* PBXTargetDependency */,
 			);
 			name = Tropicalytics;
 			productName = Tropicalytics;
-			productReference = 96199037BF78A999576FA839 /* Tropicalytics.framework */;
+			productReference = F66A3AD5F3C42945C074B85D70D879CB /* Tropicalytics.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D4EE7AAC0919C75B959EC4F3 /* Pods-Tropicalytics_Tests */ = {
+		71A2CBBB6F73FB1925C80B5FA2E5520D /* Tropicalytics-Tropicalytics */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C3E539887478B6501D41D443 /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Tests" */;
+			buildConfigurationList = B2EEF24F4326C964D73B456E39E03374 /* Build configuration list for PBXNativeTarget "Tropicalytics-Tropicalytics" */;
 			buildPhases = (
-				B67E2EE9E252492648D4EEA2 /* Sources */,
-				60906E09C1AE35575754979D /* Frameworks */,
-				8E6C53FFEFB03CD7DFB5884F /* Headers */,
+				D26ADA9C93375690EE3A2DB614495B8F /* Sources */,
+				EBEDA26C460270751B48587DDAA00ECB /* Frameworks */,
+				52DAC0F040BE672D748E71B6E6D557C1 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3CADB298B95D1B49AD0DFF47 /* PBXTargetDependency */,
-				E5E473FD52EA69AF41CA2D2C /* PBXTargetDependency */,
-				858AE5E4AE6A2DA39D2D86E9 /* PBXTargetDependency */,
-				8EF15F7147E17E584EED1422 /* PBXTargetDependency */,
-				2AC8182836FF864D8DD73798 /* PBXTargetDependency */,
+			);
+			name = "Tropicalytics-Tropicalytics";
+			productName = "Tropicalytics-Tropicalytics";
+			productReference = 736825C14AB0DC5059B2304F01FCE599 /* Tropicalytics.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		7ED05A47B4D2AF1C8B82912EA5AD8856 /* Pods-Tropicalytics_Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CCC825235EF60901D397363E45267D3C /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Example" */;
+			buildPhases = (
+				BC42F59DC7701220687E176805C285D3 /* Sources */,
+				40031F77D6C4EDDA67D483EB7EF0293E /* Frameworks */,
+				4F7B4C347AB1AB77D1F5FDF9D96BC3B5 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				690FD25A338D55B7018DA99C9D1E530F /* PBXTargetDependency */,
+				10E153D5BEA6CBB9CC07024367DE0DB5 /* PBXTargetDependency */,
+				65CD00823259227C74061F269E0DB040 /* PBXTargetDependency */,
+			);
+			name = "Pods-Tropicalytics_Example";
+			productName = "Pods-Tropicalytics_Example";
+			productReference = A4E58C232854B6285AEF18F572A5C7E2 /* Pods_Tropicalytics_Example.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9A466F5C83182C5DE3B2448AD24B9B0E /* MAObjCRuntime */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E6DEE50DF3AA62F9665F0DF95792B214 /* Build configuration list for PBXNativeTarget "MAObjCRuntime" */;
+			buildPhases = (
+				89DF67287224A4FBA422149D8376C1C6 /* Sources */,
+				C53809CE4D7D1E47C6A852D8F1FAEE1F /* Frameworks */,
+				2F2CE9EFDEAE59F21BD87EC36534E4A1 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MAObjCRuntime;
+			productName = MAObjCRuntime;
+			productReference = 3F5D9459A3E51F32781F3DE3C78A7BC3 /* MAObjCRuntime.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C25D4D02F3AE31E78A1963C27E5336A0 /* Pods-Tropicalytics_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1FB966E1E0977A308A18D3E71AB15D4F /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Tests" */;
+			buildPhases = (
+				383974E8714B845FFA7D86E6C92B5D89 /* Sources */,
+				3576A6E9DFD28A6934DA791A048FAC76 /* Frameworks */,
+				6122C7B205E5C001D36B1CA204A7C259 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C8B81A714EE5AD04C81E4CCB89F13493 /* PBXTargetDependency */,
+				7AFF4B1C5712B59D62BE3C618AC67C2E /* PBXTargetDependency */,
+				44381AC8C6E08A8C726648C80CB0312F /* PBXTargetDependency */,
+				49DC74757FC5B68A933D907436301988 /* PBXTargetDependency */,
+				A6908416E798A25DBB170A0E37C5014D /* PBXTargetDependency */,
 			);
 			name = "Pods-Tropicalytics_Tests";
 			productName = "Pods-Tropicalytics_Tests";
-			productReference = 402B31CD85EDCCFCE6EE6487 /* Pods_Tropicalytics_Tests.framework */;
+			productReference = 8630638A604C4758596FE7FAE50837E8 /* Pods_Tropicalytics_Tests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D45F1F7801E597113BC0502F5733DC4C /* Specta */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 936E2E47FDF91F613E2A1C05F8750ABC /* Build configuration list for PBXNativeTarget "Specta" */;
+			buildPhases = (
+				A961799BE17B3718F1BCCCDB477D7AB6 /* Sources */,
+				4B14518ED39BDEC8F751269D29E93EF9 /* Frameworks */,
+				5CDF07A95AFF678D3836B9CF0F96E10C /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Specta;
+			productName = Specta;
+			productReference = 1858124E2B51C0A1B46A86524BCBC335 /* Specta.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		B2932AAD8FF3E8F5B06C0279 /* Project object */ = {
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0700;
 			};
-			buildConfigurationList = 058E748BBBFB4A013A927689 /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 6BF5D780D6FC7E0346AB6685;
-			productRefGroup = 37402DB123D422FAE9CEFCAF /* Products */;
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = 745A9E0954268DB21A3B89D66E70F042 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				901977407F28FD34ED7BD7ED /* AFNetworking */,
-				CA2488A6AAF184795C789D52 /* Expecta */,
-				A4CA4C94B10CA708DEC0F48B /* MAObjCRuntime */,
-				84D5D9A22D32015D8E08133F /* Pods-Tropicalytics_Example */,
-				D4EE7AAC0919C75B959EC4F3 /* Pods-Tropicalytics_Tests */,
-				555C0DCF4037F17BB7332590 /* Specta */,
-				D3505E04070EDD818D3D70A8 /* Tropicalytics */,
-				344CD463CAA283D595371E33 /* Tropicalytics-Tropicalytics */,
+				1C3436CEA5C3D39764C5F54374794ECB /* AFNetworking */,
+				0D888F29E05E498D0CD91A51D28599A5 /* Expecta */,
+				9A466F5C83182C5DE3B2448AD24B9B0E /* MAObjCRuntime */,
+				7ED05A47B4D2AF1C8B82912EA5AD8856 /* Pods-Tropicalytics_Example */,
+				C25D4D02F3AE31E78A1963C27E5336A0 /* Pods-Tropicalytics_Tests */,
+				D45F1F7801E597113BC0502F5733DC4C /* Specta */,
+				2E506988AC2C89E31E46A3E227C81671 /* Tropicalytics */,
+				71A2CBBB6F73FB1925C80B5FA2E5520D /* Tropicalytics-Tropicalytics */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		9193FBE7DDE3CA32B5CC5370 /* Resources */ = {
+		2CD1F995B882FA8E9DEA0BF06E2E4DD4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B57335169177F4A558D98236BD8D38A /* Tropicalytics.bundle in Resources */,
+				C834C57C115A6D9667B7296B80C019E2 /* Tropicalytics.xcdatamodeld in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C0AF2F2B70EB8B371B9C4D0C /* Resources */ = {
+		52DAC0F040BE672D748E71B6E6D557C1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7D2BD6C36E94928494FCEF6E /* Tropicalytics.bundle in Resources */,
-				D5E0A8D0E1585CDF25731C3C /* Tropicalytics.xcdatamodeld in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0FC7CE59C0D54DFFA4ED9432 /* Sources */ = {
+		1F17F426378DF5EC8DFB10304B8C4BA4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				30F6086CF96A8DF8C53CD90E /* MAObjCRuntime-dummy.m in Sources */,
-				128D231839E4F3235E91E943 /* MARTNSObject.m in Sources */,
-				1DF711C01ADC8661FAA070A7 /* RTIvar.m in Sources */,
-				4A304B4D22ADF94D63B14AA8 /* RTMethod.m in Sources */,
-				F1BA9CEB54D79AC77B7156D7 /* RTProperty.m in Sources */,
-				2DEE6CE1E116061DD71558E0 /* RTProtocol.m in Sources */,
-				A0A68206644823DA66AD79C3 /* RTUnregisteredClass.m in Sources */,
+				3F1BC9BAFFEEABB1ABC7614DF0FC97D5 /* AFAutoPurgingImageCache.m in Sources */,
+				E0D4045AC4C1B41917FCA23A042D18B2 /* AFHTTPSessionManager.m in Sources */,
+				CFA8D6B529A0EBFF0316F2629AB2556E /* AFImageDownloader.m in Sources */,
+				A6C6019D45BE62C61210A9CC619368EF /* AFNetworkActivityIndicatorManager.m in Sources */,
+				3D2789FC760A97301909F0B1201626CD /* AFNetworking-dummy.m in Sources */,
+				68A38977EBAE334DC3C22386D00D2622 /* AFNetworkReachabilityManager.m in Sources */,
+				20607BE2B1E5F31765026E5AC64DB27D /* AFSecurityPolicy.m in Sources */,
+				DFFA215EEAA8DDBD540076927535275C /* AFURLRequestSerialization.m in Sources */,
+				B5852322ADE88AAD56EE042B80BA81E4 /* AFURLResponseSerialization.m in Sources */,
+				707B1A7541C8DBDDE8C27896A61370BE /* AFURLSessionManager.m in Sources */,
+				6ED4ABEE8A5F51F5ECB59FA1781D29C6 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
+				AF03C11A1FAC8132AD3749D8F541701A /* UIButton+AFNetworking.m in Sources */,
+				2E8A32ED46194EDBE22146271F6D26DE /* UIImageView+AFNetworking.m in Sources */,
+				5FF6453E55785669885F626B853FD2AA /* UIProgressView+AFNetworking.m in Sources */,
+				174202BD6AE0E4A41F5CE66E975EAE52 /* UIRefreshControl+AFNetworking.m in Sources */,
+				A462945883F7729B185B64B679A6BFBE /* UIWebView+AFNetworking.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8DBC65589318CE17065FB02F /* Sources */ = {
+		383974E8714B845FFA7D86E6C92B5D89 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5170A96AE044CC8DF87FB8B /* AFAutoPurgingImageCache.m in Sources */,
-				2317A16916CFF242B20ABA54 /* AFHTTPSessionManager.m in Sources */,
-				96780802415FD6B22A19E792 /* AFImageDownloader.m in Sources */,
-				E703A751F305B05070F99985 /* AFNetworkActivityIndicatorManager.m in Sources */,
-				339DCB3304D18DE0F62F8305 /* AFNetworking-dummy.m in Sources */,
-				D5AACA5306BBB4F20A40A3CD /* AFNetworkReachabilityManager.m in Sources */,
-				1DD03553F59B2774903A735F /* AFSecurityPolicy.m in Sources */,
-				152AA45FAAFF34E9870EEA38 /* AFURLRequestSerialization.m in Sources */,
-				CAF2D63F526FB94C08B64C75 /* AFURLResponseSerialization.m in Sources */,
-				73BDB5994044B72C226E400B /* AFURLSessionManager.m in Sources */,
-				6869759896488955785C1ED7 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
-				C825FCB3E9AC004EC2E7E253 /* UIButton+AFNetworking.m in Sources */,
-				2947D19064F65320BC364B4D /* UIImageView+AFNetworking.m in Sources */,
-				4C18C7BE7540A2D7D00DED06 /* UIProgressView+AFNetworking.m in Sources */,
-				781A6E6FF0BE081DB88E5A63 /* UIRefreshControl+AFNetworking.m in Sources */,
-				D46E2E902DB724D2ABD71C51 /* UIWebView+AFNetworking.m in Sources */,
+				17EF5B386E320620CDB766CB6AD80700 /* Pods-Tropicalytics_Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		96E033C6D1627AC145025B62 /* Sources */ = {
+		89DF67287224A4FBA422149D8376C1C6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E07FA68FB88EE2F43F6AC94E3F82A248 /* MAObjCRuntime-dummy.m in Sources */,
+				81E0DB04CED585BE1AF0A843A1EFDEAE /* MARTNSObject.m in Sources */,
+				D754C2C15B62D7473C4A6EDC64C66DBF /* RTIvar.m in Sources */,
+				C782AC36CFE36AA4324D41C0B4EB0310 /* RTMethod.m in Sources */,
+				8633BE2B6F523A83EDCAFAB77EBC4AD3 /* RTProperty.m in Sources */,
+				D85BCB05C5D881668BB7EE5A99DA9B7B /* RTProtocol.m in Sources */,
+				01FDB9509628825F65A36D617903EA60 /* RTUnregisteredClass.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B67E2EE9E252492648D4EEA2 /* Sources */ = {
+		A961799BE17B3718F1BCCCDB477D7AB6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				40BE52741CD9A7E66421556C /* Pods-Tropicalytics_Tests-dummy.m in Sources */,
+				494767D9F1B586F1F97BF993498F002F /* Specta-dummy.m in Sources */,
+				599298371E33787177EF97722CF48412 /* SpectaDSL.m in Sources */,
+				59876AFB4A82B77A0FCC8CDB2A7FEBF4 /* SpectaUtility.m in Sources */,
+				8DC751D799A71AA97FD7F5DE1A171210 /* SPTCallSite.m in Sources */,
+				23DC772ACCF5806AE9CFDA1604FC400C /* SPTCompiledExample.m in Sources */,
+				6C3940612920F2F97069AF6AAF4BDAFD /* SPTExample.m in Sources */,
+				9436299B947A7E6B7474EEB264505FE3 /* SPTExampleGroup.m in Sources */,
+				D3E1977B4A831F8D6E7FAA5A90E26720 /* SPTSharedExampleGroups.m in Sources */,
+				AC9BA05FC3672457AD6AC317D2A819F9 /* SPTSpec.m in Sources */,
+				FE062E2D92883A1DBD397A9CBC0F60D4 /* SPTTestSuite.m in Sources */,
+				3A31EDB6BCFB40F2DE1A3A68A6071960 /* XCTestCase+Specta.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C794149434AA8A3E335870FA /* Sources */ = {
+		B239BD93C67DE976C7F3A1AD982A0A58 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB7AB19AC31BB726254ACF85 /* EXPBlockDefinedMatcher.m in Sources */,
-				3A6E3CD118809157B91CB2BE /* EXPDoubleTuple.m in Sources */,
-				435A79D2A1805B20C070CF45 /* Expecta-dummy.m in Sources */,
-				A39764BEBE7F8B60D5641F5E /* ExpectaObject.m in Sources */,
-				8AE22680CE8E4DFEFB0F55B2 /* ExpectaSupport.m in Sources */,
-				C071573E14F6A12699EB126C /* EXPExpect.m in Sources */,
-				0D26EC8CE675DBE050161BB6 /* EXPFloatTuple.m in Sources */,
-				84D99C0B61E73119FAE1025D /* EXPMatcherHelpers.m in Sources */,
-				9A6A47BCC9A8B6E5BEA990EC /* EXPMatchers+beCloseTo.m in Sources */,
-				3AB7C3CEC2DB6BF4C18C6F23 /* EXPMatchers+beFalsy.m in Sources */,
-				38CD428160025386FAF921D6 /* EXPMatchers+beginWith.m in Sources */,
-				FB37F1DD5F11E37C3D767FCE /* EXPMatchers+beGreaterThan.m in Sources */,
-				E2E789A028BB92B8E351E239 /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */,
-				BF73794C88A61252F1FFE8F7 /* EXPMatchers+beIdenticalTo.m in Sources */,
-				7330E612F1F01ABB6A220CCC /* EXPMatchers+beInstanceOf.m in Sources */,
-				99E7AEAC017AC626D849D70B /* EXPMatchers+beInTheRangeOf.m in Sources */,
-				378B9767A7319A87C393B3AB /* EXPMatchers+beKindOf.m in Sources */,
-				EAFA6AAC94C49B30F53BD2A8 /* EXPMatchers+beLessThan.m in Sources */,
-				1779872CD95E17F9C81C9DD7 /* EXPMatchers+beLessThanOrEqualTo.m in Sources */,
-				197590488A2B936E4D890B58 /* EXPMatchers+beNil.m in Sources */,
-				D75EADAAF51082BE44F186D0 /* EXPMatchers+beSubclassOf.m in Sources */,
-				0BB45BC75A6FC91057949F0A /* EXPMatchers+beSupersetOf.m in Sources */,
-				8C56E3C71D3B56CA0A9E6AE8 /* EXPMatchers+beTruthy.m in Sources */,
-				518C9DFA997EFAF20A1542DE /* EXPMatchers+conformTo.m in Sources */,
-				F4CB18F57912B6BD917941EC /* EXPMatchers+contain.m in Sources */,
-				AC36ED0055C3BEB0511989AF /* EXPMatchers+endWith.m in Sources */,
-				58CE7B77423B11B5C2257C1B /* EXPMatchers+equal.m in Sources */,
-				7E99FEEE1417C10C9CCA45A2 /* EXPMatchers+haveCountOf.m in Sources */,
-				14807A6CDAF38A1D4DA7E9F3 /* EXPMatchers+match.m in Sources */,
-				3CA5A14DA11CD9A390EDC982 /* EXPMatchers+postNotification.m in Sources */,
-				F290B8B5520999D48C128BC3 /* EXPMatchers+raise.m in Sources */,
-				BCDD78432A5AB27A5B2F4430 /* EXPMatchers+raiseWithReason.m in Sources */,
-				CA0B5A059398CFBB0716210C /* EXPMatchers+respondTo.m in Sources */,
-				A6438E6BCD88379CED7F6419 /* EXPUnsupportedObject.m in Sources */,
-				C50127F3B6E8C26E0007AAC4 /* NSValue+Expecta.m in Sources */,
+				5B2D4A621D3DA971A474776AF36BB073 /* EXPBlockDefinedMatcher.m in Sources */,
+				BC55C8365AEFF8217F6A567607754854 /* EXPDoubleTuple.m in Sources */,
+				204D694B03BFF3B244A6AB73FACFFC43 /* Expecta-dummy.m in Sources */,
+				94C47C87E397972CE98F75929F3B706C /* ExpectaObject.m in Sources */,
+				4BBCBB9D8EF0B241A4A4FE4982985481 /* ExpectaSupport.m in Sources */,
+				805E425BBEF7A6133E32E1D30A073010 /* EXPExpect.m in Sources */,
+				CE3F4ECBB0BC095577D66AE50C8E604C /* EXPFloatTuple.m in Sources */,
+				201BF9C605852822CA5A65ADE282A310 /* EXPMatcherHelpers.m in Sources */,
+				BA12B131F10BCE3BE6E9A02FC908FE9D /* EXPMatchers+beCloseTo.m in Sources */,
+				17572374B2AE183C6347C41E8DF8E579 /* EXPMatchers+beFalsy.m in Sources */,
+				F12D57414A73406831CC032A7170DBFF /* EXPMatchers+beginWith.m in Sources */,
+				1312A7D381C51428CF481E33E3D37901 /* EXPMatchers+beGreaterThan.m in Sources */,
+				1B0389CD88AA949B34DC7269030FEC6F /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */,
+				66A27898E989A3FA5C15AA671C4536F0 /* EXPMatchers+beIdenticalTo.m in Sources */,
+				76D337327C10A7555447B69AA1562647 /* EXPMatchers+beInstanceOf.m in Sources */,
+				9BB9159FBA757600D3D4C0FF645F3911 /* EXPMatchers+beInTheRangeOf.m in Sources */,
+				87FD5F0F682CDEB6A348CA448889E3EA /* EXPMatchers+beKindOf.m in Sources */,
+				0EBFA5FBE4953A83B677CE2A75746761 /* EXPMatchers+beLessThan.m in Sources */,
+				D83677C54D2226C67886A525B0B46FBE /* EXPMatchers+beLessThanOrEqualTo.m in Sources */,
+				2C0A8737FDB9B9C6A6BDF437FD11334C /* EXPMatchers+beNil.m in Sources */,
+				BEFFE9FFE52E9A0833A7D2D8FB67EB4D /* EXPMatchers+beSubclassOf.m in Sources */,
+				6F278423C8AE1DA47F35E374BB5B91EC /* EXPMatchers+beSupersetOf.m in Sources */,
+				0C6FF91EB1F0391ED75DC72D31D159EF /* EXPMatchers+beTruthy.m in Sources */,
+				DB30F82FB1BE083D9471B965FB500CA2 /* EXPMatchers+conformTo.m in Sources */,
+				FC20596ABFE14A61F171A29FD03275E7 /* EXPMatchers+contain.m in Sources */,
+				918E06480F28F27361B19D19432F8538 /* EXPMatchers+endWith.m in Sources */,
+				1AB3304B6884F626BC54150AC7565E18 /* EXPMatchers+equal.m in Sources */,
+				403292D82DA62291204BF59524BC4EDB /* EXPMatchers+haveCountOf.m in Sources */,
+				FC45858927D3B6A0F922C4B697B04A38 /* EXPMatchers+match.m in Sources */,
+				931D410B9F8ACB935883DF8C59F9C93E /* EXPMatchers+postNotification.m in Sources */,
+				2CFE2898496C1C7096DB8DA43AF19103 /* EXPMatchers+raise.m in Sources */,
+				FE8E34356D24F6759A8B010ED2F5707B /* EXPMatchers+raiseWithReason.m in Sources */,
+				E0A077DFB064B79685B810CCEFB2F1EF /* EXPMatchers+respondTo.m in Sources */,
+				EF6497EE123F6BC0C1B09717437C5908 /* EXPUnsupportedObject.m in Sources */,
+				B84431CF8C64F363A334AA7089F6C134 /* NSValue+Expecta.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DBF552DCEF2B086768A0B005 /* Sources */ = {
+		BC42F59DC7701220687E176805C285D3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1440513A97436C4923381D29 /* Specta-dummy.m in Sources */,
-				49528D65D0D4547C71B7B3B8 /* SpectaDSL.m in Sources */,
-				49B30041048561CEF1EAEC1A /* SpectaUtility.m in Sources */,
-				5518C43275A7D142094F9467 /* SPTCallSite.m in Sources */,
-				476BC9E1F94FC56B7352CD13 /* SPTCompiledExample.m in Sources */,
-				7B4C57D4F4269965FBAF385C /* SPTExample.m in Sources */,
-				BEDC89ED6A7023C1599E6844 /* SPTExampleGroup.m in Sources */,
-				99CD20FF6B0A191DA3A2DB88 /* SPTSharedExampleGroups.m in Sources */,
-				5CD05AB2A994AE0940918660 /* SPTSpec.m in Sources */,
-				0627959C385A70ADD8902F14 /* SPTTestSuite.m in Sources */,
-				A59683C8276D2D24DC6ED5D9 /* XCTestCase+Specta.m in Sources */,
+				CBB5E3ADE44538D569D63A9FF7003BB4 /* Pods-Tropicalytics_Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E6C3374E900FE6D140FB0CF7 /* Sources */ = {
+		BFAA8C7F4D04651847AEB37B750C163B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				55DAE6EA4E7563435E904EC7 /* Pods-Tropicalytics_Example-dummy.m in Sources */,
+				950B9F547AD949C32ABE5F20C8FDDD2F /* contents in Sources */,
+				7E3542B8B4D6B017C763EA83D1FA9293 /* TPLAPIClient.m in Sources */,
+				DC702B3EA680EFEBC472A1E0AC8C07DD /* TPLAppUtilities.m in Sources */,
+				F6F9E850AF0799AEC46391604D5254E0 /* TPLBatchDetails.m in Sources */,
+				4ACEDCD4909C909CD15AACCC43A7B089 /* TPLConfiguration.m in Sources */,
+				3335B1AFA6CE35BCE9EA402F68C18A1B /* TPLDatabase.m in Sources */,
+				06071F3814A1707B85A8D74D95B96683 /* TPLDeviceInfo.m in Sources */,
+				0A86BDD666FEB55E3276435C816F8B1F /* TPLDeviceUtilities.m in Sources */,
+				A09327D92920BB0EDF8F2B97249FC997 /* TPLEvent.m in Sources */,
+				9D70C9E416B6F71AE612A42465CB6D39 /* TPLFieldGroup.m in Sources */,
+				FD9C6838BA7084DACC934D868AA0D388 /* TPLHeader.m in Sources */,
+				42483EECCC29200E3295EAFD4E1738E8 /* TPLRequestManager.m in Sources */,
+				A1D998E7B4EF6598D2163CC1BF72BF97 /* TPLUniqueIdentifier.m in Sources */,
+				5BFF41C4949CA8CB6BAA45B2754D96A6 /* TPLUtilities.m in Sources */,
+				770CAD284D566918F2623C2E034000B3 /* Tropicalytics-dummy.m in Sources */,
+				7C2D978E5E9C044BADB8BAFA2E30A3E6 /* Tropicalytics.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F6EDA88643495C343AFDA136 /* Sources */ = {
+		D26ADA9C93375690EE3A2DB614495B8F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4279D3D3A84DD46E16083AE4 /* TPLAPIClient.m in Sources */,
-				C6B20EEE055241BE8F95508A /* TPLAppUtilities.m in Sources */,
-				62FB84498D0C842CDB1BB4A7 /* TPLBatchDetails.m in Sources */,
-				DB04415BB7941629953F2A21 /* TPLConfiguration.m in Sources */,
-				05B4637AE966844CA97772A0 /* TPLDatabase.m in Sources */,
-				3FC91667EBDFA264C605A873 /* TPLDeviceInfo.m in Sources */,
-				AFD58BE89DE7BEA830A0BFB6 /* TPLDeviceUtilities.m in Sources */,
-				4AF5AC664E03C77837573F2A /* TPLEvent.m in Sources */,
-				CE3191927D695F5F688107DB /* TPLFieldGroup.m in Sources */,
-				E151FBC46A903249245AFC18 /* TPLHeader.m in Sources */,
-				E3180D70318AFD838FACFE47 /* TPLRequestManager.m in Sources */,
-				8073FA0DA56A4E801B5F554C /* TPLUniqueIdentifier.m in Sources */,
-				E60E8C28363A214699F7B694 /* TPLUtilities.m in Sources */,
-				9601E08089C105C40D1F6061 /* Tropicalytics-dummy.m in Sources */,
-				B7CD90AC422EA97CB79DB66C /* Tropicalytics.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		24DB3324E7B86C01AB014266 /* PBXTargetDependency */ = {
+		10E153D5BEA6CBB9CC07024367DE0DB5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = MAObjCRuntime;
-			target = A4CA4C94B10CA708DEC0F48B /* MAObjCRuntime */;
-			targetProxy = EFFE6BD33B87BBF1FBCC5413 /* PBXContainerItemProxy */;
+			target = 9A466F5C83182C5DE3B2448AD24B9B0E /* MAObjCRuntime */;
+			targetProxy = A575C8515D32A39D080C06882EBD5D25 /* PBXContainerItemProxy */;
 		};
-		2AC8182836FF864D8DD73798 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tropicalytics;
-			target = D3505E04070EDD818D3D70A8 /* Tropicalytics */;
-			targetProxy = D973371143277DA70D76F2A4 /* PBXContainerItemProxy */;
-		};
-		3CADB298B95D1B49AD0DFF47 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AFNetworking;
-			target = 901977407F28FD34ED7BD7ED /* AFNetworking */;
-			targetProxy = 25ABC5DEFDF95185163910E2 /* PBXContainerItemProxy */;
-		};
-		7EB4FA2DAE5EFA9B180DF85F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tropicalytics;
-			target = D3505E04070EDD818D3D70A8 /* Tropicalytics */;
-			targetProxy = 73CED46867DB8A1274BFDB2D /* PBXContainerItemProxy */;
-		};
-		858AE5E4AE6A2DA39D2D86E9 /* PBXTargetDependency */ = {
+		44381AC8C6E08A8C726648C80CB0312F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = MAObjCRuntime;
-			target = A4CA4C94B10CA708DEC0F48B /* MAObjCRuntime */;
-			targetProxy = F43886CA6C83797CAE4412C3 /* PBXContainerItemProxy */;
+			target = 9A466F5C83182C5DE3B2448AD24B9B0E /* MAObjCRuntime */;
+			targetProxy = F1B72B0E45FDC11C17FF0E2EB42AB284 /* PBXContainerItemProxy */;
 		};
-		8B6B65114EA4E3888F22C4C6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AFNetworking;
-			target = 901977407F28FD34ED7BD7ED /* AFNetworking */;
-			targetProxy = 0C281E642DE54C7006A787C4 /* PBXContainerItemProxy */;
-		};
-		8EF15F7147E17E584EED1422 /* PBXTargetDependency */ = {
+		49DC74757FC5B68A933D907436301988 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Specta;
-			target = 555C0DCF4037F17BB7332590 /* Specta */;
-			targetProxy = C1694B938C6F669A4EB179B9 /* PBXContainerItemProxy */;
+			target = D45F1F7801E597113BC0502F5733DC4C /* Specta */;
+			targetProxy = 0D9B966EE00FFBFA5606C789C8ACA3FB /* PBXContainerItemProxy */;
 		};
-		8F8F9D44EE0B0985EBFDBE92 /* PBXTargetDependency */ = {
+		65CD00823259227C74061F269E0DB040 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Tropicalytics-Tropicalytics";
-			target = 344CD463CAA283D595371E33 /* Tropicalytics-Tropicalytics */;
-			targetProxy = B5C1420571AD582EA3143733 /* PBXContainerItemProxy */;
+			name = Tropicalytics;
+			target = 2E506988AC2C89E31E46A3E227C81671 /* Tropicalytics */;
+			targetProxy = 858EBA66B3F2334C0D88D469C2FCB6C7 /* PBXContainerItemProxy */;
 		};
-		8FFC161691AC0DB8ABA02939 /* PBXTargetDependency */ = {
+		690FD25A338D55B7018DA99C9D1E530F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AFNetworking;
-			target = 901977407F28FD34ED7BD7ED /* AFNetworking */;
-			targetProxy = 5B1ED5CFB9DB1DC0B5B54A67 /* PBXContainerItemProxy */;
+			target = 1C3436CEA5C3D39764C5F54374794ECB /* AFNetworking */;
+			targetProxy = 4023CA49EF33585409708FDCAF2933E3 /* PBXContainerItemProxy */;
 		};
-		D4E5739D606D9A5565DE6B4F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = MAObjCRuntime;
-			target = A4CA4C94B10CA708DEC0F48B /* MAObjCRuntime */;
-			targetProxy = AFE9B7E8156E6ECA63190F2B /* PBXContainerItemProxy */;
-		};
-		E5E473FD52EA69AF41CA2D2C /* PBXTargetDependency */ = {
+		7AFF4B1C5712B59D62BE3C618AC67C2E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Expecta;
-			target = CA2488A6AAF184795C789D52 /* Expecta */;
-			targetProxy = 795E33A724C334E9DA8D1B18 /* PBXContainerItemProxy */;
+			target = 0D888F29E05E498D0CD91A51D28599A5 /* Expecta */;
+			targetProxy = 39BB80002617237CA403B80B35E590F6 /* PBXContainerItemProxy */;
+		};
+		903DD9CE23247874822F61A8B4CC18A7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = MAObjCRuntime;
+			target = 9A466F5C83182C5DE3B2448AD24B9B0E /* MAObjCRuntime */;
+			targetProxy = FE51DC0E12A41E136B41CCD2C9F39376 /* PBXContainerItemProxy */;
+		};
+		A6908416E798A25DBB170A0E37C5014D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Tropicalytics;
+			target = 2E506988AC2C89E31E46A3E227C81671 /* Tropicalytics */;
+			targetProxy = F318E5A918DF8C9E5E868836FC36196A /* PBXContainerItemProxy */;
+		};
+		AD1C2D7E43247C25292589D799673AF5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Tropicalytics-Tropicalytics";
+			target = 71A2CBBB6F73FB1925C80B5FA2E5520D /* Tropicalytics-Tropicalytics */;
+			targetProxy = 7BB28BB8BC0752CE65CBF028B5E5D7B7 /* PBXContainerItemProxy */;
+		};
+		C8B81A714EE5AD04C81E4CCB89F13493 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AFNetworking;
+			target = 1C3436CEA5C3D39764C5F54374794ECB /* AFNetworking */;
+			targetProxy = 560FED28C55799C180CA80BE621DF0BA /* PBXContainerItemProxy */;
+		};
+		CBAAE057770D1D95F89E40B9FAF98BA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AFNetworking;
+			target = 1C3436CEA5C3D39764C5F54374794ECB /* AFNetworking */;
+			targetProxy = ADF6E39EC53C18960D24659B91A38FBC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		00A7B453C5E1EADC1DC5C70B /* Release */ = {
+		015FF5A708A161A10402AC8B85A25B13 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B1B55C8F76AC655BCAF3C7B1 /* Tropicalytics.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				PRODUCT_NAME = Tropicalytics;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
-		0217CA9E2C0D29845A24E59A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 071D002A3DD913E005C979C5 /* MAObjCRuntime.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/MAObjCRuntime/MAObjCRuntime-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/MAObjCRuntime/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/MAObjCRuntime/MAObjCRuntime.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = MAObjCRuntime;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		05F4849CBB0F07B55F961390 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9ECD3B87940A157976092A08 /* Pods-Tropicalytics_Tests.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Pods-Tropicalytics_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_Tropicalytics_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		1203EBE8EDD1C034D6CF820A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B1B55C8F76AC655BCAF3C7B1 /* Tropicalytics.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Tropicalytics/Tropicalytics-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Tropicalytics/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Tropicalytics/Tropicalytics.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Tropicalytics;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		360B3F42DFCA9F8CE58E91FD /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		492A2854DC413FA32CEF2235 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0AC0FE3EC835E966AD24ED03 /* Specta.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Specta/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Specta;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		51ECC60A186E3F984AA6B366 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0AC0FE3EC835E966AD24ED03 /* Specta.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Specta/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Specta;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		645A2D0963E7339F5FB38BB8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C3D1A69BFEADD6D75EDCE592 /* Expecta.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Expecta/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Expecta/Expecta.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Expecta;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		93DA7CA95B132490AFE6C056 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1C27927ECAFF35F0D646FC77 /* AFNetworking.xcconfig */;
+			baseConfigurationReference = 9E7EC431E31C96FE95D4C77B14BA468E /* AFNetworking.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1966,9 +1757,9 @@
 			};
 			name = Release;
 		};
-		96C37A50A9A5A168D7E35352 /* Release */ = {
+		0F33B950088C5370B61F8C29CBD32EB5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C67DAD95B64BBA021F7B0431 /* Pods-Tropicalytics_Example.release.xcconfig */;
+			baseConfigurationReference = 574875DBC633C280CE29B4C5C92C3B2C /* Pods-Tropicalytics_Example.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1996,9 +1787,39 @@
 			};
 			name = Release;
 		};
-		9AABB814D819419922C5BB06 /* Release */ = {
+		21C4C6E8485CB8A9C374318AF1B68070 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B1B55C8F76AC655BCAF3C7B1 /* Tropicalytics.xcconfig */;
+			baseConfigurationReference = 66C686FBFB1C276659C7CCC3E6055D1B /* Pods-Tropicalytics_Tests.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Pods-Tropicalytics_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_Tropicalytics_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		77E184A1208C69A07B06B8C2143BFC36 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C2251CFFE0AEB3F7789BCC2FA0429033 /* Tropicalytics.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2013,7 +1834,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Tropicalytics/Tropicalytics.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = Tropicalytics;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2021,9 +1842,108 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
+			name = Debug;
+		};
+		78B1779BC8C18F605E2AE90B4D96351F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9E7EC431E31C96FE95D4C77B14BA468E /* AFNetworking.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/AFNetworking/AFNetworking-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AFNetworking/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/AFNetworking/AFNetworking.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = AFNetworking;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		79D032F125E1C152AD32A3CCD01CFEE1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B0FC275883179BBF9A4E8547B8C41319 /* Pods-Tropicalytics_Tests.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Pods-Tropicalytics_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_Tropicalytics_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8C6F145DD369F3B36CB49EC61A87F24D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 84CF0E427569F2E1E2677C6C75D1A30C /* Pods-Tropicalytics_Example.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-Tropicalytics_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-Tropicalytics_Example/Pods-Tropicalytics_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_Tropicalytics_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		91860FC24A61DB4AD4AF6CA6E0D96757 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C2251CFFE0AEB3F7789BCC2FA0429033 /* Tropicalytics.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = Tropicalytics;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
 			name = Release;
 		};
-		9BCA26D428D7BC9CEC3F23BC /* Debug */ = {
+		A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2062,9 +1982,9 @@
 			};
 			name = Debug;
 		};
-		B54E6B7EFE97E7211128E6C6 /* Debug */ = {
+		B296B7EF6297CC3A7697265C2160419A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1C27927ECAFF35F0D646FC77 /* AFNetworking.xcconfig */;
+			baseConfigurationReference = C2251CFFE0AEB3F7789BCC2FA0429033 /* Tropicalytics.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2073,25 +1993,25 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/AFNetworking/AFNetworking-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AFNetworking/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Tropicalytics/Tropicalytics-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Tropicalytics/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/AFNetworking/AFNetworking.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = AFNetworking;
+				MODULEMAP_FILE = "Target Support Files/Tropicalytics/Tropicalytics.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Tropicalytics;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
-		D10C0CE719BC5D6AB8079D24 /* Debug */ = {
+		BB45FDED7F97515B5B325AB2DF4B83DC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AD2A1D02AF7B57563074447F /* Pods-Tropicalytics_Example.debug.xcconfig */;
+			baseConfigurationReference = A2698707ECE89224BC884265E7F119A9 /* Specta.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2100,28 +2020,25 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-Tropicalytics_Example/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Specta/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-Tropicalytics_Example/Pods-Tropicalytics_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_Tropicalytics_Example;
+				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Specta;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
-		DE8090CB3565DB928A2104BC /* Debug */ = {
+		BC52B1DFEA513FC29129F89F0ECC80AE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B1B55C8F76AC655BCAF3C7B1 /* Tropicalytics.xcconfig */;
+			baseConfigurationReference = C2251CFFE0AEB3F7789BCC2FA0429033 /* Tropicalytics.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				PRODUCT_NAME = Tropicalytics;
@@ -2131,36 +2048,9 @@
 			};
 			name = Debug;
 		};
-		EA3359025AAA53BD93E4C3AE /* Release */ = {
+		C27F9C5B78D8D2343AAB00973A9ADB5E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C3D1A69BFEADD6D75EDCE592 /* Expecta.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Expecta/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Expecta/Expecta.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Expecta;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		EAA03B5668329AB66691B113 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 071D002A3DD913E005C979C5 /* MAObjCRuntime.xcconfig */;
+			baseConfigurationReference = AF517D87C43C257FAFED6A2201585887 /* MAObjCRuntime.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2185,9 +2075,9 @@
 			};
 			name = Debug;
 		};
-		F1A9F945E2B0B2415DAA5153 /* Debug */ = {
+		D1A5E9EE8135386FF07E809691531791 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC76EBF54E48BAACC61331AF /* Pods-Tropicalytics_Tests.debug.xcconfig */;
+			baseConfigurationReference = A2698707ECE89224BC884265E7F119A9 /* Specta.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2196,17 +2086,14 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Specta/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-Tropicalytics_Tests/Pods-Tropicalytics_Tests.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_Tropicalytics_Tests;
+				PRODUCT_NAME = Specta;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2215,86 +2102,201 @@
 			};
 			name = Debug;
 		};
+		D95ABB670BF106714613BF606E7FF6DC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DE3064393EAFA98ADCBB0F51F9928D61 /* Expecta.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Expecta/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Expecta/Expecta.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Expecta;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D9D9F52BC6BE0344E53A83433CE5C963 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DE3064393EAFA98ADCBB0F51F9928D61 /* Expecta.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Expecta/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Expecta/Expecta.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Expecta;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F603411FD0130ECE0E7DE2995702D6FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AF517D87C43C257FAFED6A2201585887 /* MAObjCRuntime.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/MAObjCRuntime/MAObjCRuntime-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/MAObjCRuntime/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/MAObjCRuntime/MAObjCRuntime.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = MAObjCRuntime;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		058E748BBBFB4A013A927689 /* Build configuration list for PBXProject "Pods" */ = {
+		1FB966E1E0977A308A18D3E71AB15D4F /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9BCA26D428D7BC9CEC3F23BC /* Debug */,
-				360B3F42DFCA9F8CE58E91FD /* Release */,
+				79D032F125E1C152AD32A3CCD01CFEE1 /* Debug */,
+				21C4C6E8485CB8A9C374318AF1B68070 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2DAAC0B40E69F5DDC5AF4161 /* Build configuration list for PBXNativeTarget "Tropicalytics" */ = {
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1203EBE8EDD1C034D6CF820A /* Debug */,
-				9AABB814D819419922C5BB06 /* Release */,
+				A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */,
+				FB45FFD90572718D82AB9092B750F0CA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5E024355FC2629788DA738B0 /* Build configuration list for PBXNativeTarget "AFNetworking" */ = {
+		57800A0D1724774333EF09E83030AA81 /* Build configuration list for PBXNativeTarget "AFNetworking" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B54E6B7EFE97E7211128E6C6 /* Debug */,
-				93DA7CA95B132490AFE6C056 /* Release */,
+				78B1779BC8C18F605E2AE90B4D96351F /* Debug */,
+				015FF5A708A161A10402AC8B85A25B13 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9413B104FFE5DFAC9D5C5B9B /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Example" */ = {
+		936E2E47FDF91F613E2A1C05F8750ABC /* Build configuration list for PBXNativeTarget "Specta" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D10C0CE719BC5D6AB8079D24 /* Debug */,
-				96C37A50A9A5A168D7E35352 /* Release */,
+				D1A5E9EE8135386FF07E809691531791 /* Debug */,
+				BB45FDED7F97515B5B325AB2DF4B83DC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C3E539887478B6501D41D443 /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Tests" */ = {
+		95C0E83C4364C98EA972AAFC120419B3 /* Build configuration list for PBXNativeTarget "Tropicalytics" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F1A9F945E2B0B2415DAA5153 /* Debug */,
-				05F4849CBB0F07B55F961390 /* Release */,
+				77E184A1208C69A07B06B8C2143BFC36 /* Debug */,
+				B296B7EF6297CC3A7697265C2160419A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CF01AC83F0DBAF75B78EA34F /* Build configuration list for PBXNativeTarget "MAObjCRuntime" */ = {
+		B2EEF24F4326C964D73B456E39E03374 /* Build configuration list for PBXNativeTarget "Tropicalytics-Tropicalytics" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				EAA03B5668329AB66691B113 /* Debug */,
-				0217CA9E2C0D29845A24E59A /* Release */,
+				BC52B1DFEA513FC29129F89F0ECC80AE /* Debug */,
+				91860FC24A61DB4AD4AF6CA6E0D96757 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DF9DB3DE873965683A3E9096 /* Build configuration list for PBXNativeTarget "Specta" */ = {
+		CCC825235EF60901D397363E45267D3C /* Build configuration list for PBXNativeTarget "Pods-Tropicalytics_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				492A2854DC413FA32CEF2235 /* Debug */,
-				51ECC60A186E3F984AA6B366 /* Release */,
+				8C6F145DD369F3B36CB49EC61A87F24D /* Debug */,
+				0F33B950088C5370B61F8C29CBD32EB5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E897CF271FA1DB0D2107516D /* Build configuration list for PBXNativeTarget "Expecta" */ = {
+		DC61702A42844E4ED762A73E8893436B /* Build configuration list for PBXNativeTarget "Expecta" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				645A2D0963E7339F5FB38BB8 /* Debug */,
-				EA3359025AAA53BD93E4C3AE /* Release */,
+				D95ABB670BF106714613BF606E7FF6DC /* Debug */,
+				D9D9F52BC6BE0344E53A83433CE5C963 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F1E4180DBD5C0AD48AADE62A /* Build configuration list for PBXNativeTarget "Tropicalytics-Tropicalytics" */ = {
+		E6DEE50DF3AA62F9665F0DF95792B214 /* Build configuration list for PBXNativeTarget "MAObjCRuntime" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DE8090CB3565DB928A2104BC /* Debug */,
-				00A7B453C5E1EADC1DC5C70B /* Release */,
+				C27F9C5B78D8D2343AAB00973A9ADB5E /* Debug */,
+				F603411FD0130ECE0E7DE2995702D6FF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2302,17 +2304,17 @@
 /* End XCConfigurationList section */
 
 /* Begin XCVersionGroup section */
-		A1BA91204A11F46AD66DAB63 /* Tropicalytics.xcdatamodeld */ = {
+		B7D3CE739FD62D60A1A6C12A25AD624E /* Tropicalytics.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				739ACA28B8090F590C00737D /* Tropicalytics.xcdatamodel */,
+				CB786BCEFF819325F842A6F68A078C71 /* Tropicalytics.xcdatamodel */,
 			);
-			currentVersion = 739ACA28B8090F590C00737D /* Tropicalytics.xcdatamodel */;
+			currentVersion = CB786BCEFF819325F842A6F68A078C71 /* Tropicalytics.xcdatamodel */;
 			path = Tropicalytics.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};
 /* End XCVersionGroup section */
 	};
-	rootObject = B2932AAD8FF3E8F5B06C0279 /* Project object */;
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 }

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Tropicalytics.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Tropicalytics.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'D3505E04070EDD818D3D70A8'
+               BlueprintIdentifier = 'FECAC7E944886F65362C90FF'
                BlueprintName = 'Tropicalytics'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Tropicalytics.framework'>

--- a/Example/Pods/Target Support Files/Tropicalytics/Tropicalytics-umbrella.h
+++ b/Example/Pods/Target Support Files/Tropicalytics/Tropicalytics-umbrella.h
@@ -5,6 +5,7 @@
 #import "TPLDatabase.h"
 #import "TPLRequestManager.h"
 #import "TPLBatchDetails.h"
+#import "TPLConstants.h"
 #import "TPLDeviceInfo.h"
 #import "TPLEvent.h"
 #import "TPLFieldGroup.h"

--- a/Example/Tests/TPLDeviceUtilitiesSpec.m
+++ b/Example/Tests/TPLDeviceUtilitiesSpec.m
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 #import "TPLDeviceUtilities.h"
+#import <Specta/Specta.h>
+#import <Expecta/Expecta.h>
 
 SpecBegin(TPLDeviceUtilities)
 

--- a/Example/Tests/TPLFieldGroupSpec.m
+++ b/Example/Tests/TPLFieldGroupSpec.m
@@ -7,9 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "TPLFieldGroup.h"
+#import <Tropicalytics/TPLFieldGroup.h>
 #import "TPLFieldGroupSubclass.h"
 #import <Specta/Specta.h>
+#import <Expecta/Expecta.h>
 
 SpecBegin(TPLFieldGroup)
 

--- a/Example/Tests/TPLHeaderSpec.m
+++ b/Example/Tests/TPLHeaderSpec.m
@@ -7,8 +7,9 @@
 //
 
 #import <Specta/Specta.h>
+#import <Expecta/Expecta.h>
 #import <Foundation/Foundation.h>
-#import "TPLHeader.h"
+#import <Tropicalytics/TPLHeader.h>
 
 SpecBegin(TPLHeader)
 

--- a/Example/Tests/TPLRecordEventSpec.m
+++ b/Example/Tests/TPLRecordEventSpec.m
@@ -1,65 +1,113 @@
 //
-//  TPLRecordEventTest.m
+//  TPLRecordEventSpec.m
 //  Tropicalytics
 //
-//  Created by KattMing on 1/28/16.
+//  Created by KattMing on 1/29/16.
 //  Copyright © 2016 Tilt.com Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
-#import "TPLEvent.h"
-#import "TPLConfiguration.h"
 #import <Specta/Specta.h>
-#import "TPLHeader.h"
-#import "Tropicalytics.h"
-#import "TPLAPIClient.h"
-#import "TPLRequestManager.h"
 #import <Expecta/Expecta.h>
+#import <Tropicalytics/TPLAPIClient.h>
+#import <Tropicalytics/TPLEvent.h>
+#import <Tropicalytics/TPLDatabase.h>
+#import <Tropicalytics/TPLConfiguration.h>
+#import <Tropicalytics/TPLRequestManager.h>
 
-static NSString *const HerokuTestURL      = @"http://tropicalyticsresponseserver.herokuapp.com";
-static NSUInteger const FlushRateConstant = 2;
+static NSString *const DummyBaseURL     = @"localhost";
+static NSUInteger const RequestFlushRate = 2;
 
-SpecBegin(TPLRecordEventSpec)
+/**
+ *  This test confirms that interacting with the Request Manager and the Database is correct.
+ *  This test will mock the API response necessary to trigger the removal of the Managed Object from Core Data.
+ */
+SpecBegin(TPLRecordEvent)
 
-describe(@"TPLRecordEventSpec", ^{
-    __block TPLAPIClient *apiClient;
+describe(@"Record Event Life Cycle", ^{
+    NSLog(@"STARTING");
+    // Setup
+    __block TPLEvent *event;
+    __block TPLDatabase *database;
+    __block TPLConfiguration *configuration;
     __block TPLRequestManager *requestManager;
-    it(@"can create an instance of TPLAPIClient for a Base URL", ^{
-        apiClient = [[TPLAPIClient alloc] initWithBaseURL:[NSURL URLWithString:@"http://localhost"]];
-        requestManager = [[TPLRequestManager alloc] initWithAPIClient:apiClient];
-        expect(apiClient).toNot.beNil;
+
+    __block NSDictionary *testEvent = @{ @"type": @"Contribution",
+                                         @"client_tstamp": @1452291633,
+                                         @"ctx": @{
+                                             @"campaign_info": @{
+                                                 @"guid": @"xxyyxxyxyxyxyxx",
+                                                 @"title": @"Chainsmokers All Day",
+                                                 @"creation_date": @"2016-01-01 00:00:00",
+                                                 @"expiration_date": @"2016-03-01 00:00:00",
+                                                 @"tilt_timestamp": @"2016-01-01 00:00:00",
+                                                 @"currency": @"USD",
+                                                 @"to_date_amt": @10,
+                                                 @"num_contributors": @1,
+                                                 @"target_amt": @10000,
+                                                 @"people_invited": @10,
+                                                 @"total_comments": @2,
+                                                 @"total_likes": @3,
+                                                 @"campaign_type": @"collect",
+                                                 @"campaign_security": @"private",
+                                                 @"target_timestamp": @"2016-03-01 00:00:00",
+                                                 @"created_platform": @"ios"
+                                             }
+                                         } };
+
+    it(@"can create a TPLConfiguration", ^{
+        configuration = [[TPLConfiguration alloc] initWithBasePath:[NSURL URLWithString:DummyBaseURL]];
+        configuration.flushRate = 2;
+        expect(configuration).toNot.beNil;
     });
-        
-    it([NSString stringWithFormat:@"should have a flush rate of %lu",(unsigned long)FlushRateConstant] , ^{
-        requestManager.flushRate = 2;
-        expect(requestManager.flushRate).to.equal(FlushRateConstant);
+
+    it(@"can create a TPLRequestManager", ^{
+        requestManager = [[TPLRequestManager alloc] initWithConfiguration:configuration];
+        expect(requestManager).toNot.beNil;
+
+        requestManager.flushRate = RequestFlushRate;
+        expect(requestManager.flushRate).to.equal(RequestFlushRate);
     });
-    
-    
-        
-        NSDictionary *testEvent = @{@"type": @"Contribution",
-                                    @"client_tstamp": @1452291633,
-                                    @"ctx": @{
-                                            @"campaign_info": @{
-                                                    @"guid": @"xxyyxxyxyxyxyxx",
-                                                    @"title": @"Chainsmokers All Day",
-                                                    @"creation_date": @"2016-01-01 00:00:00",
-                                                    @"expiration_date": @"2016-03-01 00:00:00",
-                                                    @"tilt_timestamp": @"2016-01-01 00:00:00",
-                                                    @"currency": @"USD",
-                                                    @"to_date_amt": @10,
-                                                    @"num_contributors": @1,
-                                                    @"target_amt": @10000,
-                                                    @"people_invited": @10,
-                                                    @"total_comments": @2,
-                                                    @"total_likes": @3,
-                                                    @"campaign_type": @"collect",
-                                                    @"campaign_security": @"private",
-                                                    @"target_timestamp": @"2016-03-01 00:00:00",
-                                                    @"created_platform": @"ios"
-                                                    }
-                                            }
-                                    };
+
+    it(@"can create a TPLDatabase", ^{
+        database = [[TPLDatabase alloc] initWithAPIClientUniqueIdentifier:configuration.apiClient.uniqueIdentifier];
+        expect(database).toNot.beNil;
+        [database resetDatabase];
+        expect([database getEventsArrayCount]).to.equal(0);
+    });
+
+    it(@"can create a TPLEvent from a dictionary", ^{
+        event = [[TPLEvent alloc] initWithEntries:testEvent];
+        expect(event).toNot.beNil;
+    });
+
+    it(@"should have the same number of keys as an event and as a dictionary", ^{
+        NSUInteger testDictionaryCount = [testEvent count];
+        NSUInteger eventCount = [[event dictionaryRepresentation] count];
+        expect(testDictionaryCount).to.equal(eventCount);
+    });
+
+    it(@"should record an event to the database", ^{
+        [database addEventToQueue:[event dictionaryRepresentation]];
+        expect([database getEventsArrayCount]).to.equal(1);
+    });
+
+
+    it(@"should send the events to the API", ^{
+        waitUntil(^(DoneCallback done) {
+            expect([database getEventsArrayCount]).to.equal(1);
+            NSArray *outboundBatchArray = [database getEventsArray];
+            NSDictionary *outboundBatchDictionary = @{
+                @"event" : [database getEventsAsJSONFromArray:outboundBatchArray]
+            };
+
+            [configuration.apiClient postWithParameters:outboundBatchDictionary completion:^(NSDictionary *response, NSError *error) {
+                [database removeEventsFromQueue:outboundBatchArray];
+                expect([database getEventsArrayCount]).to.equal(0);
+                done();
+            }];
+        });
+    });
 });
 
 SpecEnd

--- a/Example/Tropicalytics.xcodeproj/project.pbxproj
+++ b/Example/Tropicalytics.xcodeproj/project.pbxproj
@@ -25,8 +25,8 @@
 		8BBEB8301C59996E006C7AD1 /* TPLDeviceUtilitiesSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBEB82F1C59996E006C7AD1 /* TPLDeviceUtilitiesSpec.m */; };
 		8BE3E00E1C56ADEE008213E8 /* TPLFieldGroupSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE3E00D1C56ADEE008213E8 /* TPLFieldGroupSpec.m */; };
 		8BE3E0111C56B680008213E8 /* TPLFieldGroupSubclass.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE3E0101C56B680008213E8 /* TPLFieldGroupSubclass.m */; };
+		BD29F6C71C5C067E00EC35A8 /* TPLRecordEventSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = BD29F6C61C5C067E00EC35A8 /* TPLRecordEventSpec.m */; };
 		BD2F6F301C4F3B5600EFF66A /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD2F6F2F1C4F3B5600EFF66A /* Launch Screen.storyboard */; };
-		BD46CE2F1C5AF397006E3CEB /* TPLRecordEventSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = BD46CE2E1C5AF397006E3CEB /* TPLRecordEventSpec.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,8 +70,8 @@
 		8BE3E00F1C56B680008213E8 /* TPLFieldGroupSubclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPLFieldGroupSubclass.h; sourceTree = "<group>"; };
 		8BE3E0101C56B680008213E8 /* TPLFieldGroupSubclass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPLFieldGroupSubclass.m; sourceTree = "<group>"; };
 		B95C6BDB732735F0DFD85CDC /* Tropicalytics.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Tropicalytics.podspec; path = ../Tropicalytics.podspec; sourceTree = "<group>"; };
+		BD29F6C61C5C067E00EC35A8 /* TPLRecordEventSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPLRecordEventSpec.m; sourceTree = "<group>"; };
 		BD2F6F2F1C4F3B5600EFF66A /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
-		BD46CE2E1C5AF397006E3CEB /* TPLRecordEventSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPLRecordEventSpec.m; sourceTree = "<group>"; };
 		D991BB0D39020C8B20CB99F3 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		E490B426688630DD2AC776D8 /* Pods-Tropicalytics_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tropicalytics_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tropicalytics_Tests/Pods-Tropicalytics_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -170,8 +170,8 @@
 				8BE3E00D1C56ADEE008213E8 /* TPLFieldGroupSpec.m */,
 				8BE3E00F1C56B680008213E8 /* TPLFieldGroupSubclass.h */,
 				8BE3E0101C56B680008213E8 /* TPLFieldGroupSubclass.m */,
-				BD46CE2E1C5AF397006E3CEB /* TPLRecordEventSpec.m */,
 				8BBEB82F1C59996E006C7AD1 /* TPLDeviceUtilitiesSpec.m */,
+				BD29F6C61C5C067E00EC35A8 /* TPLRecordEventSpec.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -414,11 +414,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BD46CE2F1C5AF397006E3CEB /* TPLRecordEventSpec.m in Sources */,
 				8BE3E00E1C56ADEE008213E8 /* TPLFieldGroupSpec.m in Sources */,
 				8B98DCDE1C52C6D2005D2F0E /* TPLHeaderSpec.m in Sources */,
 				8BBEB8301C59996E006C7AD1 /* TPLDeviceUtilitiesSpec.m in Sources */,
 				8BE3E0111C56B680008213E8 /* TPLFieldGroupSubclass.m in Sources */,
+				BD29F6C71C5C067E00EC35A8 /* TPLRecordEventSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Tropicalytics/TPLViewController.m
+++ b/Example/Tropicalytics/TPLViewController.m
@@ -12,8 +12,11 @@
 #import <Tropicalytics/TPLHeader.h>
 #import <Tropicalytics/TPLEvent.h>
 
+//Leaving this for now because it will help us test things. We will update the ReadMe to explain how to use the Basic Server checked into this project and this
+//will be removed once we are nearly finished with this project.
 static NSString *const urlBasePath = @"http://tropicalyticsresponseserver.herokuapp.com";
-static NSString *const otherBasePath = @"http://localhost:4555";
+
+static NSString *const otherBasePath = @"http://localhost:4567";
 
 @interface TPLViewController ()
 
@@ -26,26 +29,26 @@ static NSString *const otherBasePath = @"http://localhost:4555";
 
 @implementation TPLViewController
 
-- (void)viewDidLoad {
+- (void) viewDidLoad {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
-    
+
     // Initialize the header payload that is sent as part of all outgoing tracking requests.
-    
+
     // Use the defaults (includes things like app version, environment, etc)...
     TPLHeader *header = [[TPLHeader alloc] initDefaultHeaderWithAppId:@"tilt_ios" source:@"app"];
-  
+
     // ...Or skip the defaults and just do your own thing.
     // TPLHeader *header = [[TPLHeader alloc] init];
 
     // Adds any arbitrary key-values to the header payload.
     [header addValues:@{
-        @"foo": @"bar",
-    }];
-    
+         @"foo": @"bar",
+     }];
+
     // Initialize the config. Passing in the header payload is optional.
     TPLConfiguration *config = [[TPLConfiguration alloc] initWithBasePath:[NSURL URLWithString:urlBasePath] header:header];
-    config.flushRate = 5;
+    config.flushRate = 2;
     // Optional: configure how requests are structured.
     // Uses the default structure:
     // All requests have "header", "device_info", "user_info" field groupings
@@ -67,69 +70,49 @@ static NSString *const otherBasePath = @"http://localhost:4555";
     //    // }
     //   @"environment": @{},
     // };
-    
+
     // Instance example:
     self.tropicalyticsInstance = [[Tropicalytics alloc] initWithConfiguration:config];
-    [self.tropicalyticsInstance recordEvent:[[TPLEvent alloc] initWithLabel:@"app" category:@"view" context:@{
-                                                                                                              @"foo": @"bar",
-                                                                                                              }]];
-    [self.tropicalyticsInstance recordEvent:[[TPLEvent alloc] initWithEntries:@{
-                                                                                 @"foo": @"bar",
-                                                                                }]];
-    
-    TPLConfiguration *otherConfig = [[TPLConfiguration alloc] initWithBasePath:[NSURL URLWithString:otherBasePath]];
-    otherConfig.flushRate = 5;
+
+    TPLConfiguration *otherConfig = [[TPLConfiguration alloc] initWithBasePath:[NSURL URLWithString:urlBasePath]];
+    otherConfig.flushRate = 2;
     [Tropicalytics sharedInstanceWithConfiguration:otherConfig];
-    
+
     self.sendEventInstanceButton = [[UIButton alloc] initWithFrame:CGRectMake(10, 10, 100, 100)];
     [self.sendEventInstanceButton setBackgroundColor:[UIColor redColor]];
     [self.view addSubview:self.sendEventInstanceButton];
     [self.sendEventInstanceButton setTitle:@"INSTANCE EVENT" forState:UIControlStateNormal];
     [self.sendEventInstanceButton addTarget:self action:@selector(instanceButtonTapped) forControlEvents:UIControlEventTouchUpInside];
-    
+
     self.sendEventSingletonButton = [[UIButton alloc] initWithFrame:CGRectMake(10, 120, 100, 100)];
     [self.sendEventSingletonButton setBackgroundColor:[UIColor redColor]];
     [self.view addSubview:self.sendEventSingletonButton];
     [self.sendEventSingletonButton setTitle:@"EVENT SINGLETON" forState:UIControlStateNormal];
     [self.sendEventSingletonButton addTarget:self action:@selector(sharedInstanceButtonTapped) forControlEvents:UIControlEventTouchUpInside];
-    
+
     UIButton *resetButton = [[UIButton alloc] initWithFrame:CGRectMake(10, 240, 100, 100)];
     [resetButton setBackgroundColor:[UIColor blueColor]];
     [self.view addSubview:resetButton];
-    
+
     [resetButton setTitle:@"RESET" forState:UIControlStateNormal];
     [resetButton addTarget:self action:@selector(resetEverything) forControlEvents:UIControlEventTouchUpInside];
-    
-    UIButton *printOutCoreDataObjects = [[UIButton alloc] initWithFrame:CGRectMake(120, 240, 100, 100)];
-    [printOutCoreDataObjects setBackgroundColor:[UIColor yellowColor]];
-    [self.view addSubview:printOutCoreDataObjects];
-    
-    [printOutCoreDataObjects setTitle:@"PRINT OBJECTS" forState:UIControlStateNormal];
-    [printOutCoreDataObjects addTarget:self action:@selector(printCoreData) forControlEvents:UIControlEventTouchUpInside];
 }
 
-//Essential a unit test for now... Will make these actual tests after Brett's TPLEvent stuff is in. This instance and the shared can run at the same time without issues.
-- (void)instanceButtonTapped {
-    for(int i = 0; i < 6; i++) {
-         [self.tropicalyticsInstance recordEvent:@(i)];
-    }
+- (void) instanceButtonTapped {
+    [self.tropicalyticsInstance recordEvent:[[TPLEvent alloc] initWithLabel:@"app" category:@"view" context:@{
+                                                 @"foo": @"bar",
+                                             }]];
 }
 
-//Essential a unit test for now... Will make these actual tests after Brett's TPLEvent stuff is in. This instance and the shared can run at the same time without issues.
-- (void)sharedInstanceButtonTapped {
-    for(int i = 0; i < 1000; i++) {
-        [[Tropicalytics sharedInstance] recordEventWithCount:@(i)];
-    }
+- (void) sharedInstanceButtonTapped {
+    [[Tropicalytics sharedInstance] recordEvent:[[TPLEvent alloc] initWithEntries:@{
+                                                     @"foo": @"bar",
+                                                 }]];
 }
 
-- (void)resetEverything {
+- (void) resetEverything {
     [[Tropicalytics sharedInstance] resetDatabase];
     [self.tropicalyticsInstance resetDatabase];
-}
-
-- (void)printCoreData {
-    [[Tropicalytics sharedInstance] printCoreData];
-    [self.tropicalyticsInstance printCoreData];
 }
 
 @end

--- a/Pod/Classes/Config/TPLConfiguration.h
+++ b/Pod/Classes/Config/TPLConfiguration.h
@@ -9,16 +9,73 @@
 #import <Foundation/Foundation.h>
 
 @class TPLHeader;
+@class TPLAPIClient;
 
 @interface TPLConfiguration : NSObject
 
-- (id)initWithBasePath:(NSURL *)basePath;
-- (id)initWithBasePath:(NSURL *)basePath header:(TPLHeader *)header;
-- (NSDictionary *)dictionaryRepresentation;
+/**
+ *  Default Initializer that will create the configuration and the underlying API client.
+ *  This will not create a header.
+ *
+ *  @param basePath The URL to receive the event
+ *
+ *  @return An instance of TPLConfiguration
+ */
+- (id) initWithBasePath:(NSURL *)basePath;
 
-@property (nonatomic, readonly) NSURL *urlBasePath;
-@property (nonatomic, readonly) TPLHeader *header;
-@property (nonatomic) NSDictionary *requestStructure;
+/**
+ *  Default Initializer that allows more flexibility and customization
+ *
+ *  @param basePath The URL to receive the event
+ *  @param header   A TPLHeader to be sent.
+ *
+ *  @return An instance of TPLConfiguration
+ */
+- (id) initWithBasePath:(NSURL *)basePath header:(TPLHeader *)header;
+
+/**
+ *  Converts the underlying header into JSON
+ *
+ *  @return a dictionary representation of the underlying header to be sent.
+ */
+- (NSDictionary *) dictionaryRepresentation;
+
+/**
+ *  Number of events in the queue before a network request will be fired.
+ */
 @property (nonatomic, assign)   NSUInteger flushRate;
+
+/**
+ *  The underlying TPLAPIClient created from initWithBasePath:
+ */
+@property (nonatomic, readonly) TPLAPIClient *apiClient;
+
+/**
+ *  The header that is created and configured when the configuration is initialized
+ */
+@property (nonatomic, readonly) TPLHeader *header;
+
+/**
+ *  Optional: configure how requests are structured.
+ *   Uses the default structure:
+ *   All requests have "header", "device_info", "user_info" field groupings
+ *   in addition to the "event" structure:
+ *       {
+ *           "header": {...},
+ *           "device_info": {...},
+ *           "user_info": {...},
+ *           "event": {...}
+ *       }
+ *   The request can also be configured however you desire:
+ *   config.requeststructure = @{
+ *   All requests will then consist of:
+ *       {
+ *           "environment": {},
+ *           "event": {...}
+ *           }
+ *           @"environment": @{},
+ *       };
+ */
+@property (nonatomic)           NSDictionary *requestStructure; // TK I think we might be able to get rid of this for something else.
 
 @end

--- a/Pod/Classes/Config/TPLConfiguration.m
+++ b/Pod/Classes/Config/TPLConfiguration.m
@@ -8,53 +8,55 @@
 
 #import "TPLConfiguration.h"
 #import "TPLHeader.h"
+#import "TPLAPIClient.h"
 
 static NSUInteger const DefaultFlushRate = 20;
 
 @interface TPLConfiguration ()
 
-@property (nonatomic, readwrite) NSURL *urlBasePath;
 @property (nonatomic, readwrite) TPLHeader *header;
 
 @end
 
 @implementation TPLConfiguration
 
-- (id)initWithBasePath:(NSURL *)basePath {
+- (id) initWithBasePath:(NSURL *)basePath {
+    NSParameterAssert(basePath);
     self = [self init];
-    if(self) {
-        _urlBasePath = basePath;
+    if (self) {
+        _apiClient = [[TPLAPIClient alloc] initWithBaseURL:basePath];
     }
-    
+
     return self;
 }
 
-- (id)initWithBasePath:(NSURL *)basePath header:(TPLHeader *)header {
+- (id) initWithBasePath:(NSURL *)basePath header:(TPLHeader *)header {
+    NSParameterAssert(header);
     self = [self initWithBasePath:basePath];
     if (self) {
         _header = header;
     }
-    
+
     return self;
 }
 
-- (NSUInteger)flushRate {
-    if(!_flushRate) {
+- (NSUInteger) flushRate {
+    if (!_flushRate) {
         _flushRate = DefaultFlushRate;
     }
-    
+
     return _flushRate;
 }
 
-- (NSDictionary *)dictionaryRepresentation {
+- (NSDictionary *) dictionaryRepresentation {
     TPLFieldGroup *requestData = [[TPLFieldGroup alloc] init];
-    
+
     if (_header != nil) {
         [requestData setValue:_header forKey:@"header"];
     }
-    
+
     //    TK Add the rest of the request data....
-    
+
     return [requestData dictionaryRepresentationWithUnderscoreKeys];
 }
 

--- a/Pod/Classes/Database/TPLDatabase.h
+++ b/Pod/Classes/Database/TPLDatabase.h
@@ -9,11 +9,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 
-/**
- *  The key for the NSManagedObject attribute in core data.
- */
-static NSString *const ManagedObjectEventKey = @"event";
-
 @class TPLAPIClient;
 
 @interface TPLDatabase : NSObject
@@ -44,16 +39,12 @@ static NSString *const ManagedObjectEventKey = @"event";
  */
 - (NSArray *) getEventsArray;
 
-// Returns the count for the events array.
-- (NSUInteger) getEventsArrayCount;
-
 /**
- *  This is just used for debugging to pretty print before we write tests
+ *  Gets the number of events in the core data array for the current API client
  *
- *  @return Returns a JSON representation of what is stored in CoreData.
+ *  @return The number of events in the array as a NSUInteger.
  */
-- (NSArray *) getEventsAsJSONArray;
-
+- (NSUInteger) getEventsArrayCount;
 
 /**
  *  Gets the event array for the current batch to be sent to the API.

--- a/Pod/Classes/Request Manager/TPLRequestManager.h
+++ b/Pod/Classes/Request Manager/TPLRequestManager.h
@@ -8,7 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-@class TPLAPIClient;
+@class TPLConfiguration;
+@class TPLEvent;
 
 @interface TPLRequestManager : NSObject
 
@@ -25,18 +26,18 @@
 /**
  *  Default initializer that will set the appropriate API client with the request.
  *
- *  @param apiClient an instance of TPLApiClient
+ *  @param configuration an instance of TPLConfiguration
  *
  *  @return instance of TPLRequestManager
  */
-- (instancetype) initWithAPIClient:(TPLAPIClient *)apiClient;
+- (instancetype) initWithConfiguration:(TPLConfiguration *)configuration;
 
 /**
  *  Sample way to record an event. This will change as we build out the structure of this.
  *
  *  @param eventData NSDictionary containing the event data.
  */
-- (void) recordEvent:(NSDictionary *)eventData;
+- (void) recordEvent:(TPLEvent *)event;
 
 /**
  *  Send events in queue to server
@@ -47,8 +48,5 @@
  *  Remove all events from local storage to start fresh for this instance of the request manager. If more than one instance has been created, they will remain.
  */
 - (void) resetDatabase;
-
-// Debugging placeholder.
-- (NSArray *) getEventsAsJSONArray;
 
 @end

--- a/Pod/Classes/TPLConstants.h
+++ b/Pod/Classes/TPLConstants.h
@@ -6,6 +6,20 @@
 //
 //
 
-#define KPLEventKey @"events"
-#define KPLDeviceKey @"device_info"
-#define KPLHeaderKey @"header"
+/**
+ *  The key for a TPLEvent object
+ */
+static NSString *const TPLEventKey  = @"events";
+/**
+ *  The key for the default device_info fields
+ */
+static NSString *const TPLDeviceKey = @"device_info";
+/**
+ *  The key for the default TPLHeader
+ */
+static NSString *const TPLHeaderKey = @"header";
+
+/**
+ *  The key for the NSManagedObject attribute in core data.
+ */
+static NSString *const ManagedObjectEventKey = @"event";

--- a/Pod/Classes/TPLEvent.h
+++ b/Pod/Classes/TPLEvent.h
@@ -26,7 +26,6 @@
  */
 + (TPLEvent *) objectWithManagedObject:(NSManagedObject *)managedObject;
 
-
 /**
  *  Initializes with the given time interval timestamp.
  *
@@ -34,7 +33,7 @@
  *
  *  @return instance
  */
--(instancetype) initWithTimeInterval:(NSTimeInterval)timestamp;
+- (instancetype) initWithTimeInterval:(NSTimeInterval)timestamp;
 
 /**
  *  Initializes with the given label and category and sets timestamp.
@@ -44,7 +43,7 @@
  *
  *  @return instance
  */
--(instancetype) initWithLabel:(NSString *)label category:(NSString *)category;
+- (instancetype) initWithLabel:(NSString *)label category:(NSString *)category;
 
 /**
  *  Initializes with the given label, category, and context and sets timestamp.
@@ -55,6 +54,6 @@
  *
  *  @return instance
  */
--(instancetype) initWithLabel:(NSString *)label category:(NSString *)category context:(NSDictionary *)context;
+- (instancetype) initWithLabel:(NSString *)label category:(NSString *)category context:(NSDictionary *)context;
 
 @end

--- a/Pod/Classes/TPLEvent.m
+++ b/Pod/Classes/TPLEvent.m
@@ -8,43 +8,44 @@
 
 #import "TPLEvent.h"
 #import "TPLDatabase.h"
+#import "TPLConstants.h"
 
 @implementation TPLEvent
 
 + (TPLEvent *) objectWithManagedObject:(NSManagedObject *)managedObject {
     TPLEvent *event = [managedObject valueForKey:ManagedObjectEventKey];
-    
+
     return event;
 }
 
--(instancetype) initWithTimeInterval:(NSTimeInterval)timestamp {
+- (instancetype) initWithTimeInterval:(NSTimeInterval)timestamp {
     self = [self init];
-    
+
     if (self) {
         _timestamp = @(timestamp);
     }
-    
+
     return self;
 }
 
--(instancetype) initWithLabel:(NSString *)label category:(NSString *)category {
+- (instancetype) initWithLabel:(NSString *)label category:(NSString *)category {
     self = [self initWithTimeInterval:[[NSDate date] timeIntervalSince1970]];
-    
+
     if (self) {
         _label = label;
         _category = category;
     }
-    
+
     return self;
 }
 
--(instancetype) initWithLabel:(NSString *)label category:(NSString *)category context:(NSDictionary *)context {
+- (instancetype) initWithLabel:(NSString *)label category:(NSString *)category context:(NSDictionary *)context {
     self = [self initWithLabel:label category:category];
-    
+
     if (self) {
         _context = context;
     }
-    
+
     return self;
 }
 

--- a/Pod/Classes/Tropicalytics.h
+++ b/Pod/Classes/Tropicalytics.h
@@ -38,12 +38,7 @@
  */
 - (id) initWithConfiguration:(TPLConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
-/**
- *  Simple way to send a prestructured event to the API. This will change as we start to support real events. Just a placeholder.
- *
- *  @param count A NSNumber representing the event number. Which is used for easy debugging.
- */
-- (void) recordEventWithCount:(NSNumber *)count;
+#pragma mark - Record Event
 
 /**
  *  Records an event wit the given event.
@@ -61,11 +56,6 @@
 - (void) recordEventWithLabel:(NSString *)label category:(NSString *)category;
 
 /**
- *  Reset the current request manager.
- */
-- (void) resetDatabase;
-
-/**
  *  Records an event with the given label, category, and context.
  *
  *  @param label    NSString event label
@@ -74,7 +64,11 @@
  */
 - (void) recordEventWithLabel:(NSString *)label category:(NSString *)category context:(NSDictionary *)context;
 
-// Place holder to ensure core data is working.
-- (void) printCoreData;
+#pragma mark - Database Helper
+
+/**
+ *  Reset the current request manager.
+ */
+- (void) resetDatabase;
 
 @end


### PR DESCRIPTION
This also cleaned up some of the ways we were passing around the `TPLAPIClient` 
