### PR TITLE
Fixes podspec for newer cocoapods

### DIFF
--- a/Tropicalytics.podspec
+++ b/Tropicalytics.podspec
@@ -29,7 +29,6 @@ Tropicalytics is a lightweight configurable analytics tool that allows you to se
     'Tropicalytics' => ['Pod/Assets/*.png']
   }
 
-  s.public_header_files = 'Pod/Classes/**/*.h'
   s.dependency 'MAObjCRuntime', '~> 0.0.1'
   s.resources = 'Pod/Classes/Tropicalytics.xcdatamodeld'
   s.preserve_paths = 'Pod/Classes/Tropicalytics.xcdatamodeld'

--- a/Tropicalytics.podspec
+++ b/Tropicalytics.podspec
@@ -24,14 +24,15 @@ Tropicalytics is a lightweight configurable analytics tool that allows you to se
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
+  s.exclude_files = 'Pod/Classes/Tropicalytics.xcdatamodeld'
   s.resource_bundles = {
     'Tropicalytics' => ['Pod/Assets/*.png']
   }
 
-   s.public_header_files = 'Pod/Classes/**/*.h'
-    s.dependency 'MAObjCRuntime', '~> 0.0.1'
-    s.resources = 'Pod/Classes/Tropicalytics.xcdatamodeld'
-    s.preserve_paths = 'Pod/Classes/Tropicalytics.xcdatamodeld'
-    s.framework = 'CoreData'
-    s.requires_arc = true
+  s.public_header_files = 'Pod/Classes/**/*.h'
+  s.dependency 'MAObjCRuntime', '~> 0.0.1'
+  s.resources = 'Pod/Classes/Tropicalytics.xcdatamodeld'
+  s.preserve_paths = 'Pod/Classes/Tropicalytics.xcdatamodeld'
+  s.framework = 'CoreData'
+  s.requires_arc = true
 end


### PR DESCRIPTION
We should exclude the xcdatamodeld from the source files, as the Pod target generator has special behavior that handles this.
https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb#L114
